### PR TITLE
Remove useless "typedef" in c++

### DIFF
--- a/Einsy.cpp
+++ b/Einsy.cpp
@@ -552,7 +552,7 @@ void setupDrivers()
     ex.mask = uiDiagMask;
 	avr_ioctl(avr, AVR_IOCTL_IOPORT_SET_EXTERNAL(ex.name), &ex);
 
-	struct TMC2130::TMC2130_cfg_t cfg;
+	TMC2130::TMC2130_cfg_t cfg;
 	cfg.iMaxMM = 255;
 	cfg.cAxis = 'X';
 	cfg.uiDiagPin = X_TMC2130_DIAG;

--- a/hwDefs/TMC2130.h
+++ b/hwDefs/TMC2130.h
@@ -41,7 +41,7 @@ class TMC2130: public SPIPeripheral
             _IRQ(POSITION_OUT,      ">tmc2130.pos_out") 
         #include "IRQHelper.h"
 
-        typedef struct TMC2130_cfg_t {
+        struct TMC2130_cfg_t {
             TMC2130_cfg_t():bInverted(false),uiStepsPerMM(100),cAxis(' '),iMaxMM(200),fStartPos(10.0),bHasNoEndStops(false){};
             bool bInverted;
             uint16_t uiStepsPerMM;
@@ -50,7 +50,7 @@ class TMC2130: public SPIPeripheral
             float fStartPos;
             uint8_t uiDiagPin;
             bool bHasNoEndStops;
-        } TMC2130_cfg_t;
+        };
         
         // Default constructor.
         TMC2130();


### PR DESCRIPTION
Only the definition is an error (in g++10), but the typedef struct is
also not needed either since we're clearly in c++ land.

After this I got it working!