### PR TITLE
std::minus is in <functional>

### DIFF
--- a/utility/GLPrint.cpp
+++ b/utility/GLPrint.cpp
@@ -22,6 +22,7 @@
 #include "GLPrint.h"
 #include "GL/glew.h"
 #include <algorithm>
+#include <functional>
 
 static constexpr int iPrintRes = 100000; //0.1mm (meters/this)
 


### PR DESCRIPTION
Required when using gcc 10 in --std=cXY mode