### PR TITLE
Add an editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+#-*-mode:conf-*-
+# editorconfig file (see EditorConfig.org)
+
+root                        = true
+
+[*]
+end_of_line                 = lf
+insert_final_newline        = true
+charset                     = utf-8
+trim_trailing_whitespace    = true
+indent_style                = tab
+indent_size                 = 4
+tab_width                   = 4
+max_line_length             = 100


### PR DESCRIPTION
Matches expected values.

trim_trailing_whitespace is on, which is a double-edged sword for some editors (not sure what do you use/prefer), since the current sources do have some amount of them.

But it's for the "greater good" ;)