### PR TITLE
Add visualization for heaters (bed/hotend)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,10 @@ set(INCLUDE_FILES
     include/PinHelper_2560.h
     include/Util.h
     include/thermistortables.h
+    utility/Color.h
+    utility/MK3SGL.h
+    utility/GLObj.h
+    utility/GLPrint.h
 )
 
 
@@ -72,6 +76,7 @@ set(EINSY_SOURCES
     hwDefs/w25x20cl.cpp
     MMU2.cpp
     include/SerialPipe.cpp
+    utility/Color.cpp
     utility/MK3SGL.cpp  
     utility/GLObj.cpp  
     utility/GLPrint.cpp

--- a/Einsy.cpp
+++ b/Einsy.cpp
@@ -253,7 +253,11 @@ void displayCB(void)		/* function called whenever redisplay needed */
 		glScalef(fX/350,4,1);
 		glTranslatef(0,fY +30,0);
 		hw.E.Draw_Simple();
-		glTranslatef(290,0,0);
+		glTranslatef(250,0,0);
+		hw.hExtruder->Draw();
+		glTranslatef(20,0,0);
+		hw.hBed->Draw();
+		glTranslatef(20,0,0);
 		hw.lSD.Draw();
 		glTranslatef(20,0,0);
 		hw.lPINDA.Draw();
@@ -665,11 +669,11 @@ void setupHeaters()
 		hw.fPrint = new Fan(5000);
 		hw.fPrint->Init(avr, DIRQLU(avr, TACH_1), 	DIRQLU(avr, FAN_PIN),	DPWMLU(avr, FAN_PIN));
 
-		hw.hBed = new Heater(0.25, 25, true);
+		hw.hBed = new Heater(0.25, 25, true,'B',30,100);
 		hw.hBed->Init(avr, NULL, DIRQLU(avr,HEATER_BED_PIN));
 		hw.hBed->ConnectTo(Heater::TEMP_OUT, hw.tBed.GetIRQ(Thermistor::TEMP_IN));
 
-		hw.hExtruder = new Heater(1.5,25.0);
+		hw.hExtruder = new Heater(1.5,25.0,false,'H',30,250);
 		hw.hExtruder->Init(avr, NULL, DIRQLU(avr, HEATER_0_PIN));
 		hw.hExtruder->ConnectTo(Heater::TEMP_OUT, hw.tExtruder.GetIRQ(Thermistor::TEMP_IN));
 }

--- a/hwDefs/Heater.cpp
+++ b/hwDefs/Heater.cpp
@@ -21,6 +21,8 @@
 	along with MK3SIM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "GL/glut.h"
+
 #include "Heater.h"
 #include "stdio.h"
 #include "math.h"
@@ -88,11 +90,15 @@ void Heater::OnDigitalChanged(struct avr_irq_t * irq, uint32_t value)
     OnPWMChanged(irq,value);
 }
 
-Heater::Heater(float fThermalMass, float fAmbientTemp, bool bIsBed):
+Heater::Heater(float fThermalMass, float fAmbientTemp, bool bIsBed,
+			   char chrLabel, float fColdTemp, float fHotTemp):
                                             m_fThermalMass(fThermalMass),
-                                            m_fAmbientTemp(fAmbientTemp), 
+                                            m_fAmbientTemp(fAmbientTemp),
                                             m_fCurrentTemp(fAmbientTemp),
-                                            m_bIsBed(bIsBed)            
+                                            m_bIsBed(bIsBed),
+                                            m_chrLabel(chrLabel),
+                                            m_fColdTemp(fColdTemp),
+                                            m_fHotTemp(fHotTemp)
 {
 
 }
@@ -117,4 +123,34 @@ void Heater::Set(uint8_t uiPWM)
 void Heater::Resume_Auto()
 {
     m_bAuto = true;
+}
+
+
+constexpr Color3fv Heater::m_colColdTemp;
+constexpr Color3fv Heater::m_colHotTemp;
+
+void Heater::Draw()
+{
+	bool bOn = m_uiPWM>0;
+
+	Color3fv colFill;
+	float v = (m_fCurrentTemp - m_fColdTemp) / (m_fHotTemp - m_fColdTemp);
+	colorLerp(m_colColdTemp, m_colHotTemp, v, colFill);
+
+    glPushMatrix();
+	    glColor3fv(colFill);
+        glBegin(GL_QUADS);
+            glVertex2f(0,10);
+            glVertex2f(20,10);
+            glVertex2f(20,0);
+            glVertex2f(0,0);
+        glEnd();
+        glColor3f(bOn,bOn,bOn);
+        glTranslatef(8,7,-1);
+        glScalef(0.05,-0.05,1);
+		glPushAttrib(GL_LINE_BIT);
+			glLineWidth(3);
+			glutStrokeCharacter(GLUT_STROKE_MONO_ROMAN,m_chrLabel);
+		glPopAttrib();
+    glPopMatrix();
 }

--- a/hwDefs/Heater.h
+++ b/hwDefs/Heater.h
@@ -26,6 +26,7 @@
 #define __HEATER_H__
 
 #include "BasePeripheral.h"
+#include "Color.h"
 
 class Heater : public BasePeripheral
 {
@@ -36,7 +37,8 @@ public:
 
     // "Thermal mass" of the heater... deg C it heats/cools per sec at full-on (PWM=255);
     // Create a new heater with ambient fAmbientTemp, and thermal mass fThermalMass
-    Heater(float fThermalMass, float fAmbientTemp, bool bIsBed = false);
+    Heater(float fThermalMass, float fAmbientTemp, bool bIsBed, char chrLabel,
+		   float fColdTemp, float fHotTemp);
 
     // Initializes the heater on "avr" and on irqPQM/irqDigital,
     void Init(avr_t *avr, avr_irq_t *irqPWM, avr_irq_t *irqDigital);
@@ -46,6 +48,9 @@ public:
 
     // Returns to automatic control after having used Set()
     void Resume_Auto();
+
+	// Draws the heater status
+	void Draw();
 
     private:
         // Hook for PWM change
@@ -62,9 +67,15 @@ public:
         bool m_bAuto = true;
         float m_fCurrentTemp = 25.0;
         float m_fAmbientTemp = 25.0;
+        float m_fColdTemp;
+        float m_fHotTemp;
         float m_fThermalMass = 1.0;
         uint16_t m_uiPWM = 0;
         bool m_bIsBed = false;
+        char m_chrLabel;
+
+	    static constexpr Color3fv m_colColdTemp = {0, 1, 1};
+	    static constexpr Color3fv m_colHotTemp = {1, 0, 0};
 };
 
 #endif /* __HEATER_H__*/

--- a/utility/Color.cpp
+++ b/utility/Color.cpp
@@ -1,0 +1,132 @@
+/*
+	Color - simple color utilities
+
+	This file is part of MK3SIM.
+
+	MK3SIM is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	MK3SIM is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with MK3SIM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Color.h"
+
+#include <algorithm>
+#include <cmath>
+
+
+void rgb2hsv(const Color3fv rgb, Color3fv hsv)
+{
+	float r = rgb[0];
+	float g = rgb[1];
+	float b = rgb[2];
+
+	float h, s;
+
+	float max = std::max(std::max(r, g), b);
+	float min = std::min(std::min(r, g), b);
+	float c = max - min;
+
+	if (c == 0.0)
+	{
+		h = 0;
+		s = 0;
+	}
+	else
+	{
+		if (max == r)
+			h = fmod(((g - b) / c), 6);
+		else if (max == g)
+			h = (b - r) / c + 2;
+		else
+			h = (r - g) / c + 4;
+		s = c / max;
+	}
+
+	hsv[0] = h * 60;
+	hsv[1] = s;
+	hsv[2] = max;
+}
+
+
+void hsv2rgb(const Color3fv hsv, Color3fv rgb)
+{
+	float h = hsv[0];
+	float s = hsv[1];
+	float v = hsv[2];
+
+	float c = v * s;
+	float x = c * (1.0 - std::abs(std::fmod(h / 60., 2) - 1));
+	float m = v - c;
+
+	if (h >= 0 && h < 60)
+	{
+		rgb[0] = c + m;
+		rgb[1] = x + m;
+		rgb[2] = m;
+	}
+	else if (h >= 60 && h < 120)
+	{
+		rgb[0] = x + m;
+		rgb[1] = c + m;
+		rgb[2] = m;
+	}
+	else if (h >= 120 && h < 180)
+	{
+		rgb[0] = m;
+		rgb[1] = c + m;
+		rgb[2] = x + m;
+	}
+	else if (h >= 180 && h < 240)
+	{
+		rgb[0] = m;
+		rgb[1] = x + m;
+		rgb[2] = c + m;
+	}
+	else if (h >= 240 && h < 300)
+	{
+		rgb[0] = x + m;
+		rgb[1] = m;
+		rgb[2] = c + m;
+	}
+	else if (h >= 300 && h < 360)
+	{
+		rgb[0] = c + m;
+		rgb[1] = m;
+		rgb[2] = x + m;
+	}
+	else
+	{
+		rgb[0] = m;
+		rgb[1] = m;
+		rgb[2] = m;
+	}
+}
+
+
+void colorLerp(const Color3fv a, const Color3fv b, float v, Color3fv c)
+{
+	Color3fv hsv_a, hsv_b, hsv_c;
+
+	if (v > 1)
+		v = 1;
+	else if (v < 0)
+		v = 0;
+
+	rgb2hsv(a, hsv_a);
+	rgb2hsv(b, hsv_b);
+
+	hsv_c[0] = hsv_a[0] + (hsv_b[0] - hsv_a[0]) * v;
+	hsv_c[1] = hsv_a[1] + (hsv_b[1] - hsv_a[1]) * v;
+	hsv_c[2] = hsv_a[2] + (hsv_b[2] - hsv_a[2]) * v;
+
+	hsv2rgb(hsv_c, c);
+}

--- a/utility/Color.h
+++ b/utility/Color.h
@@ -1,0 +1,25 @@
+/*
+	Color - simple color utilities
+
+	This file is part of MK3SIM.
+
+	MK3SIM is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	MK3SIM is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with MK3SIM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+typedef float Color3fv[3];
+
+// Interpolate between 2 RGB colors
+void colorLerp(const Color3fv a, const Color3fv b, float v, Color3fv c);


### PR DESCRIPTION
Visualize temperature using a color ramp (30-250 for the hotend, 30-100 for the bed), show the PWM state using the LED label color.

I had to thicken the text in order to make the label a bit more visible.
My plan is also to use the label thickness to indicate thermistor state (to simulate issues)

![out](https://user-images.githubusercontent.com/1017726/83811012-51d07d00-a6b9-11ea-98d7-f78007bb6976.gif)
