### PR TITLE
Fix more warnings

### DIFF
--- a/3rdParty/arcball/Matrix.hpp
+++ b/3rdParty/arcball/Matrix.hpp
@@ -249,7 +249,7 @@ class mat4
 		mat4(void)
 			{ load_identity(); }
 		mat4(const mat4 & m)
-			{ for (int i=0; i<16; ++i) x[i]=m.x[i]; }
+			{ *this = m; }
 		mat4(float x11, float x12, float x13, float x14,
 				float x21, float x22, float x23, float x24,
 				float x31, float x32, float x33, float x34,
@@ -321,6 +321,8 @@ class mat4
 					+	x[ 3]*x[ 4]*x[ 9]*x[14]
 					-	x[15]*x[ 8]*x[ 5]*x[ 2];
 			}
+		inline mat4 & operator = (const mat4 & m)
+			{ for (int i=0; i<16; ++i) x[i]=m.x[i]; return *this; }
 		inline mat4 & operator *= (float f)
 			{ for (int i=0; i<16; ++i) x[i]*=f; return *this; }
 		inline mat4 & operator += (const mat4 & m)

--- a/parts/Board.h
+++ b/parts/Board.h
@@ -118,7 +118,7 @@ namespace Boards
 
 			inline void SetResetFlag(){m_bReset = true;}
 			inline void SetQuitFlag(){m_bQuit = true;}
-			inline volatile bool GetQuitFlag(){return m_bQuit;}
+			inline bool GetQuitFlag(){return m_bQuit;}
 
 			inline bool IsStopped(){ return m_pAVR->state == cpu_Stopped;}
 			inline bool IsPaused(){ return m_bPaused;}

--- a/parts/ScriptHost.cpp
+++ b/parts/ScriptHost.cpp
@@ -280,6 +280,7 @@ void ScriptHost::OnAVRCycle()
 				break;
 			case LS::Unhandled:
 				printf("ScriptHost: Unhandled action, considering this an error.\n");
+				/* FALLTHRU */
 			case LS::Error:
 				printf("ScriptHost: Script FAILED on line %d\n",m_iLine);
 				m_iLine = m_script.size(); // Error, end scripting.

--- a/utility/FatImage.h
+++ b/utility/FatImage.h
@@ -77,7 +77,7 @@ class FatImage
 
 		static uint32_t GetDataStartAddr(Size imgSize) { return FirstFATAddr + (Sector2Bytes(SectorsPerFat(imgSize))<<1); } // <<10 = 2*512, 2*bytespersector.
 
-		static const uint32_t SectorsPerFat(Size size)
+		static uint32_t SectorsPerFat(Size size)
 		{
 			switch (size)
 			{


### PR DESCRIPTION
- Useless return argument qualifiers
- Deprecated syntesized copy
- Implicit fallthrough