### PR TITLE
Implement DEDGE support in TMC2130

### DIFF
--- a/parts/components/TMC2130.cpp
+++ b/parts/components/TMC2130.cpp
@@ -225,8 +225,17 @@ avr_cycle_count_t TMC2130::OnStandStillTimeout(avr_t *avr, avr_cycle_count_t whe
 // Called when STEP is triggered.
 void TMC2130::OnStepIn(struct avr_irq_t * irq, uint32_t value)
 {
-    if (!value || irq->value) return; // Only step on rising pulse
     if (!m_bEnable) return;
+	if (!m_regs.defs.CHOPCONF.dedge)
+	{
+		// In normal mode only step on rising pulse
+		if (!value || irq->value) return;
+	}
+	else
+	{
+		// With DEDGE step on each value change
+		if (value == irq->value) return;
+	}
     CancelTimer(m_fcnStandstill,this);
 	//TRACE2(printf("TMC2130 %c: STEP changed to %02x\n",m_cAxis,value));
     if (m_bDir)

--- a/parts/components/TMC2130.h
+++ b/parts/components/TMC2130.h
@@ -160,8 +160,29 @@ class TMC2130: public SPIPeripheral, public Scriptable
                     uint8_t drv_err :1;
                     uint8_t uv_cp   :1;
                 } GSTAT;
-                uint32_t _unimplemented[110];   // 0x02 - 0x6E
-                struct                      //0x6F
+                uint32_t _unimplemented[107]; //0x02 - 0x6B
+				struct                        //0x6C
+				{
+					uint32_t toff		:4;
+					uint32_t hstrt		:3;
+					uint32_t hend		:4;
+					uint32_t fd3		:1;
+					uint32_t disfdcc	:1;
+					uint32_t rndtf		:1;
+					uint32_t chm		:1;
+					uint32_t tbl		:2;
+					uint32_t vsense		:1;
+					uint32_t vhighfs	:1;
+					uint32_t vhighchm	:1;
+					uint32_t sync		:4;
+					uint32_t mres		:4;
+					uint32_t intpol		:1;
+					uint32_t dedge		:1;
+					uint32_t diss2g		:1;
+					uint32_t			:1;
+				} CHOPCONF;
+                uint32_t _unimplemented2[2]; //0x6D - 0x6E
+                struct                       //0x6F
                 {
                     uint16_t SG_RESULT   :10;
                     uint8_t             :5;


### PR DESCRIPTION
Define the 0x6C CHOPCONF register and handle the DEDGE bit

### Description

See https://github.com/prusa3d/Prusa-Firmware/pull/2789

### Behaviour/ Breaking changes

Pretty much plug&play ;)

### Have you tested the changes?

Works on my machine™

### Other

Although we add the entire definition of CHOPCONF, all we care about is the DEDGE bit.
