### PR TITLE
Remove TIMSK hack, sync with simavr, timer fix

### DIFF
--- a/MK404.cpp
+++ b/MK404.cpp
@@ -323,12 +323,15 @@ int main(int argc, char *argv[])
 		cout << "GL_VENDOR    : " << glGetString(GL_VENDOR) << endl;
 		cout << "GL_RENDERER  : " << glGetString(GL_RENDERER) << endl;
 		cout << "GLEW_VERSION : " << glewGetString(GLEW_VERSION) << endl;
-		cout << "GLSL VERSION : " << glGetString(GL_SHADING_LANGUAGE_VERSION) << endl;
+		//cout << "GLSL VERSION : " << glGetString(GL_SHADING_LANGUAGE_VERSION) << endl;
 		glDebugMessageCallback( GLErrorCB, 0 );
-		// glDebugMessageControl(GL_DONT_CARE,
-        //               GL_DONT_CARE,
-        //               GL_DEBUG_SEVERITY_NOTIFICATION,
-        //               0, nullptr, GL_FALSE);
+		if (argSpam.getValue()<1)
+		{
+			glDebugMessageControl(GL_DONT_CARE,
+						GL_DONT_CARE,
+						GL_DEBUG_SEVERITY_NOTIFICATION,
+						0, nullptr, GL_FALSE);
+		}
 		glEnable(GL_DEBUG_OUTPUT);
 		initGL(iWinW, iWinH);
 

--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -225,8 +225,9 @@ namespace Boards
 		// TIMSK2 hack for stock prusa firmware.
 		if (!GetDisableWorkarounds())
 		{
-			avr_regbit_t rb = AVR_IO_REGBITS(0x70, 0, 0b111);
-			avr_regbit_setto(m_pAVR,rb,0x01);
+			// Sweet, this is no longer necessary, it seems!
+			//avr_regbit_t rb = AVR_IO_REGBITS(0x70, 0, 0b111);
+			//	avr_regbit_setto(m_pAVR,rb,0x01);
 		}
 
 		//Reset all SPI SS lines


### PR DESCRIPTION
### Description

Removes a timer hack necessary due to wrong timer modes. Eliminates the need for `--no-hacks` with Marlin firmware.

### Behaviour/ Breaking changes

None - should have unbroken things reliant on phase correct vs normal pwm subtleties.

### Have you tested the changes?

yes, ran Marlin and Prusa firmware with no args/changes necessary anymore.

### Other

Cleans up some output spam if not running with `-vv`

### Linked issues:

- closes #75 
