### PR TITLE
218 broken visuals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,7 +233,13 @@ if (ENABLE_THREAD_SANITY)
 	target_link_libraries(MK404 -fsanitize=thread)
 endif()
 
-target_link_libraries(MK404 pthread util m ${GLUT_LIBRARIES} OpenGL::GL OpenGL::GLU GLEW::GLEW ${SDL_LIBRARY} tinyobjloader ${LIBSIMAVR} ${LIBELF_LIBRARIES})
+if(CYGWIN)
+target_link_libraries(MK404 GLEW)
+else()
+target_link_libraries(MK404 GLEW::GLEW)
+endif()
+
+target_link_libraries(MK404 pthread util m ${GLUT_LIBRARIES} OpenGL::GL OpenGL::GLU ${SDL_LIBRARY} tinyobjloader ${LIBSIMAVR} ${LIBELF_LIBRARIES})
 endif()
 
 add_custom_command(TARGET MK404 POST_BUILD

--- a/utility/GLObj.cpp
+++ b/utility/GLObj.cpp
@@ -276,7 +276,7 @@ bool GLObj::LoadObjAndConvert(const char* filename) {
 	{
 		for (size_t s = 0; s < shapes.size(); s++) {
 			std::vector<float> vb;  // pos(3float), normal(3float), color(3float)
-			int iMatlId = 0;
+			int iMatlId = shapes[s].mesh.material_ids[0];
 			for (size_t f = 0; f < shapes[s].mesh.indices.size() / 3; f++) {
 				tinyobj::index_t idx0 = shapes[s].mesh.indices[3 * f + 0];
 				tinyobj::index_t idx1 = shapes[s].mesh.indices[3 * f + 1];
@@ -286,7 +286,8 @@ bool GLObj::LoadObjAndConvert(const char* filename) {
 
 				if (current_material_id != iMatlId)
 				{
-					//printf("Submaterial in shape %s: %u\n",shapes[s].name.c_str(),current_material_id);
+					printf("Submaterial in shape %s: %u\n",shapes[s].name.c_str(),current_material_id);
+					printf("sub-Object %s: is # %u\n",shapes[s].name.c_str(),(int)m_DrawObjects.size());
 					AddObject(vb,iMatlId);
 					vb.clear();
 				}
@@ -407,7 +408,7 @@ bool GLObj::LoadObjAndConvert(const char* filename) {
 #endif
 				}
 			}
-			//printf("Object %s: is # %u\n",shapes[s].name.c_str(),(int)m_DrawObjects.size());
+			printf("Object %s: is # %u\n",shapes[s].name.c_str(),(int)m_DrawObjects.size());
 			AddObject(vb, iMatlId);
 			// // OpenGL viewer does not support texturing with per-face material.
 			// if (shapes[s].mesh.material_ids.size() > 0 && shapes[s].mesh.material_ids.size() > s) {

--- a/utility/MK3SGL.cpp
+++ b/utility/MK3SGL.cpp
@@ -148,7 +148,17 @@ void MK3SGL::KeyCB(unsigned char c, int x, int y)
 		m_flDbg3 = m_flDbg3+0.001f;
 	else if (c == '9')
 		m_flDbg3 = m_flDbg3-0.001f;
-
+	else if (c == '7')
+	{
+		m_iDbg ++;
+		m_MMUBase.SetSubobjectVisible(m_iDbg,false);
+	}
+	else if (c == '8')
+	{
+		m_iDbg --;
+		m_MMUBase.SetSubobjectVisible(m_iDbg,true);
+	}
+	printf("Int: %d\n",m_iDbg.load());
 	printf("Offsets: %03f, %03f, %03f,\n",m_flDbg.load(),m_flDbg2.load(), m_flDbg3.load());
 	if (m_pParent)
 		m_pParent->OnKeyPress(c,x,y);

--- a/utility/MK3SGL.cpp
+++ b/utility/MK3SGL.cpp
@@ -451,7 +451,8 @@ void MK3SGL::Draw()
 			glPopMatrix();
 			if (m_bBedOn)
 			{
-				glTranslatef(0.016,0,-0.244);
+				glTranslatef(m_flDbg,m_flDbg2,m_flDbg3);
+				m_Objs->ApplyBedLEDTransform();
 				DrawLED(1,0,0);
 			}
 		glPopMatrix();

--- a/utility/MK3SGL.h
+++ b/utility/MK3SGL.h
@@ -176,6 +176,7 @@ class MK3SGL: public BasePeripheral, public Scriptable
 		inline void DebugTx(){glTranslatef(m_flDbg,m_flDbg2,m_flDbg3);}
 
 		atomic<float> m_flDbg = {0.0f}, m_flDbg2 = {0.0f}, m_flDbg3 = {0.0f};
+		atomic_int m_iDbg = {0};
 
 		enum Actions
 		{

--- a/utility/MK3S_Bear.h
+++ b/utility/MK3S_Bear.h
@@ -143,7 +143,7 @@ class MK3S_Bear: public OBJCollection
 		 	m_pEVis->GetCenteringTransform(fTransform);
 		 	fTransform[1] +=.0015f;
 		 	glTranslatef (-fTransform[0] , -fTransform[1], -fTransform[2]);
-		 	glRotatef((-36.f/28.f)*3.f*(fEPos*1000.f),0,0,1);
+		 	glRotatef((-36.f/28.f)*6.f*(fEPos*1000.f),0,0,1);
 		 	glTranslatef (fTransform[0], fTransform[1], fTransform[2]);
 		 	m_pEVis->Draw();
 		}

--- a/utility/MK3S_Bear.h
+++ b/utility/MK3S_Bear.h
@@ -77,7 +77,7 @@ class MK3S_Bear: public OBJCollection
 
 		inline float GetScaleFactor() override { return m_pBaseObj->GetScaleFactor();};
 
-		inline void SetNozzleCam(bool bOn) override { m_pE->SetSubobjectVisible(100,!bOn); }
+		inline void SetNozzleCam(bool bOn) override { m_pE->SetSubobjectVisible(89,!bOn); }
 
 		virtual void GetBaseCenter(float fTrans[3]) override
 		{

--- a/utility/MK3S_Bear.h
+++ b/utility/MK3S_Bear.h
@@ -67,6 +67,12 @@ class MK3S_Bear: public OBJCollection
 
 		inline void ApplyPLEDTransform() override {glTranslatef(-0.201000, -0.062000, -0.45);};
 
+		inline void ApplyBedLEDTransform() override
+		{
+			glTranslatef(-0.109000, 0.238000, -0.412998);
+			glRotatef(-90,1,0,0);
+		};
+
 		inline void ApplyPrintTransform() override { glTranslatef(-0.131000, 0.236000, 0.173000);};
 
 		inline float GetScaleFactor() override { return m_pBaseObj->GetScaleFactor();};

--- a/utility/MK3S_Full.h
+++ b/utility/MK3S_Full.h
@@ -39,9 +39,9 @@ class MK3S_Full: public MK3S_Lite
 			SetName("Full");
 			AddObject(ObjClass::Z, "assets/Z_AXIS.obj", 0,fZCorr,0);
 			if (bMMU)
-				AddObject(ObjClass::Other, "assets/E_MMU.obj",fXCorr,fZCorr,0,MM_TO_M)->SetKeepNormalsIfScaling(true);
+				AddObject(ObjClass::X, "assets/E_MMU.obj",fXCorr,fZCorr,0,MM_TO_M)->SetKeepNormalsIfScaling(true);
 			else
-				AddObject(ObjClass::Other, "assets/E_STD.obj",fXCorr,fZCorr,0,MM_TO_M)->SetKeepNormalsIfScaling(true);
+				AddObject(ObjClass::X, "assets/E_STD.obj",fXCorr,fZCorr,0,MM_TO_M)->SetKeepNormalsIfScaling(true);
 			 m_pBaseObj = AddObject(ObjClass::Fixed, "assets/Stationary.obj");
 		};
 

--- a/utility/MK3S_Lite.h
+++ b/utility/MK3S_Lite.h
@@ -75,6 +75,8 @@ class MK3S_Lite: public OBJCollection
 
 		inline void ApplyPLEDTransform() override {glTranslatef(-0.044,-0.210,0.f);};
 
+		inline void ApplyBedLEDTransform() override {glTranslatef(0.042000, 0.084000, 0.048000);};
+
 		inline void ApplyPrintTransform() override { glTranslatef(0.024,0.084,-0.281); };
 
 		virtual void GetBaseCenter(float fTrans[3]) override

--- a/utility/MK3S_Lite.h
+++ b/utility/MK3S_Lite.h
@@ -33,7 +33,7 @@ class MK3S_Lite: public OBJCollection
 		MK3S_Lite(bool bMMU):OBJCollection("Lite")
 		{
 			AddObject(ObjClass::Y, "assets/Y_AXIS.obj", 0, 0, -0.141);
-			AddObject(ObjClass::Y, "assets/SSSheet.obj", 0.025,0.083,0.431 + -0.141);
+			AddObject(ObjClass::PrintSurface, "assets/SSSheet.obj", 0.025,0.083,0.431 + -0.141);
 			AddObject(ObjClass::Media, "assets/SDCard.obj",0,0,0,MM_TO_M)->SetKeepNormalsIfScaling(true);
 			AddObject(ObjClass::X, "assets/X_AXIS.obj",-0.044,-0.210,0);
 			m_pKnob = AddObject(ObjClass::Other, "assets/LCD-knobR2.obj");

--- a/utility/MK3S_Lite.h
+++ b/utility/MK3S_Lite.h
@@ -117,7 +117,7 @@ class MK3S_Lite: public OBJCollection
 			m_pEVis->GetCenteringTransform(fTransform);
 			fTransform[1] +=.0015f;
 			glTranslatef (-fTransform[0] , -fTransform[1], -fTransform[2]);
-			glRotatef((-36.f/28.f)*3.f*(fEPos*1000.f),0,0,1);
+			glRotatef((-36.f/28.f)*6.f*(fEPos*1000.f),0,0,1);
 			glTranslatef (fTransform[0], fTransform[1], fTransform[2]);
 			m_pEVis->Draw();
 		}

--- a/utility/OBJCollection.h
+++ b/utility/OBJCollection.h
@@ -78,6 +78,7 @@ class OBJCollection
 		virtual void OnLoadComplete(){};
 
 		virtual inline void ApplyPLEDTransform() {};
+		virtual inline void ApplyBedLEDTransform() {};
 		virtual inline void ApplyLCDTransform() {};
 		virtual inline void ApplyPrintTransform(){};
 


### PR DESCRIPTION
### Description

Fixes a bug and some busted visuals as a result of the bear cleanup

### Behaviour/ Breaking changes

Bug in GLObj would cause items to have inflated object indices, meaning any calls to set an object's properties by index would be changing the wrong object.

LCD brightness is still broken (will fix before merging)

### Have you tested the changes?

Yes - MMU LEDs appear correct now, heatbed LED is in the correct place for both sets of visuals, sheet hides properly with `T` key, E-vis now spins a bit faster.

### Linked issues:

 - Closes #218 
