### PR TITLE
Improve MRES implementation

### DIFF
--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -133,7 +133,7 @@ namespace Boards
 		TryConnect(X_ENABLE_PIN,	X, TMC2130::ENABLE_IN);
 		TryConnect(X,TMC2130::DIAG_OUT, X_TMC2130_DIAG);
 
-		cfg.uiStepsPerMM = 400;
+		cfg.uiFullStepsPerMM = 400*16;
 		cfg.iMaxMM = 219;
 
 		Z.SetConfig(cfg);
@@ -145,7 +145,7 @@ namespace Boards
 		TryConnect(Z, TMC2130::DIAG_OUT, Z_TMC2130_DIAG);
 
 		cfg.bInverted = true;
-		cfg.uiStepsPerMM = 100;
+		cfg.uiFullStepsPerMM = 100*16;
 		cfg.iMaxMM = 220;
 
 		Y.SetConfig(cfg);
@@ -158,7 +158,7 @@ namespace Boards
 
 		cfg.bHasNoEndStops = true;
 		cfg.fStartPos = 0;
-		cfg.uiStepsPerMM = 280;
+		cfg.uiFullStepsPerMM = 280*8;
 
 		E.SetConfig(cfg);
 		AddHardware(E);

--- a/parts/boards/MM_Control_01.cpp
+++ b/parts/boards/MM_Control_01.cpp
@@ -39,7 +39,7 @@ namespace Boards
 		TryConnect(SHIFT_CLOCK,m_shift,HC595::IN_CLOCK);
 
 		TMC2130::TMC2130_cfg_t cfg;
-		cfg.uiStepsPerMM = 25;
+		cfg.uiFullStepsPerMM = 280*8;
 		cfg.fStartPos = 0;
 		cfg.bHasNoEndStops = true;
 
@@ -52,7 +52,7 @@ namespace Boards
 		m_Extr.ConnectFrom(m_shift.GetIRQ(HC595::BIT0),	TMC2130::DIR_IN);
 		m_Extr.ConnectFrom(m_shift.GetIRQ(HC595::BIT1),	TMC2130::ENABLE_IN);
 
-		cfg.uiStepsPerMM = 50;
+		cfg.uiFullStepsPerMM = 400*16;
 		cfg.iMaxMM = 70;
 		cfg.bInverted = true;
 		cfg.bHasNoEndStops = false;
@@ -65,7 +65,7 @@ namespace Boards
 		m_Sel.ConnectFrom(m_shift.GetIRQ(HC595::BIT2), TMC2130::DIR_IN);
 		m_Sel.ConnectFrom(m_shift.GetIRQ(HC595::BIT3), TMC2130::ENABLE_IN);
 
-		cfg.uiStepsPerMM = 8;
+		cfg.uiFullStepsPerMM = 8*16;
 		cfg.iMaxMM = 200;
 		m_Idl.SetConfig(cfg);
 		AddHardware(m_Idl);

--- a/parts/boards/Test_Board.cpp
+++ b/parts/boards/Test_Board.cpp
@@ -61,7 +61,7 @@ namespace Boards
 
 		TMC2130::TMC2130_cfg_t cfg;
 		cfg.iMaxMM = 20;
-		cfg.uiStepsPerMM=1;
+		cfg.uiFullStepsPerMM=16;
 
 		m_TMC.SetConfig(cfg);
 		AddHardware(m_TMC);

--- a/parts/components/MMU2.cpp
+++ b/parts/components/MMU2.cpp
@@ -161,10 +161,10 @@ void MMU2::OnPulleyFeedIn(struct avr_irq_t * ,uint32_t value)
 
 	if (m_bAutoFINDA)
 	{
-   		SetPin(FINDA_PIN,posOut>24.0f);
+   		SetPin(FINDA_PIN,posOut>33.0f);
 		// Reflect the distance out for IR sensor triggering.
 		RaiseIRQ(FEED_DISTANCE, value);
-		RaiseIRQ(FINDA_OUT,posOut>24.f);
+		RaiseIRQ(FINDA_OUT,posOut>33.f);
 	}
 	else
 	{

--- a/parts/components/PINDA.cpp
+++ b/parts/components/PINDA.cpp
@@ -126,7 +126,7 @@ void PINDA::CheckTrigger()
 	}
 
     // Just calc the nearest MBL point and report it.
-    uint8_t iX = round(((m_fPos[0] - m_fOffset[0])/255.0)*7);
+    uint8_t iX = floor(((m_fPos[0] - m_fOffset[0])/255.0)*7);
     uint8_t iY = floor(((m_fPos[1] - m_fOffset[1])/210.0)*7);
 
     float fZTrig = gsl::at(m_mesh.points,iX+(7*iY));

--- a/parts/components/TMC2130.cpp
+++ b/parts/components/TMC2130.cpp
@@ -30,6 +30,7 @@
 # include <GL/gl.h>           // for glVertex3f, glColor3f, glBegin, glEnd
 #endif
 #include <algorithm>          // for min
+#include <cmath>
 #include <cstring>           // for memset
 
 //#define TRACE(_w) _w
@@ -153,9 +154,7 @@ void TMC2130::ProcessCommand()
 
 		if(m_cmdProc.bitsIn.address == 0x6C) // CHOPCONF
 		{
-			// updating CHOPCONF requires updating the current limits
-			cfg.fStartPos = m_fCurPos;
-			SetConfig(cfg);
+			m_uiStepIncrement = std::pow(2,m_regs.defs.CHOPCONF.mres);
 		}
     }
     else
@@ -234,16 +233,16 @@ void TMC2130::OnStepIn(struct avr_irq_t * irq, uint32_t value)
 	//TRACE2(printf("TMC2130 %c: STEP changed to %02x\n",m_cAxis,value));
     if (m_bDir)
 	{
-        m_iCurStep--;
+        m_iCurStep-=m_uiStepIncrement;
 	}
     else
 	{
-        m_iCurStep++;
+        m_iCurStep+=m_uiStepIncrement;
 	}
     bool bStall = false;
     if (!cfg.bHasNoEndStops)
     {
-        if (m_iCurStep==-1)
+        if (m_iCurStep<0)
         {
             m_iCurStep = 0;
             bStall = true;
@@ -352,10 +351,10 @@ void TMC2130::Init(struct avr_t * avr)
 
 float TMC2130::StepToPos(int32_t step)
 {
-	return static_cast<float>(step)/16*static_cast<float>(1u<<m_regs.defs.CHOPCONF.mres)/static_cast<float>(cfg.uiStepsPerMM);
+	return static_cast<float>(step)/static_cast<float>(cfg.uiFullStepsPerMM);
 }
 
 int32_t TMC2130::PosToStep(float pos)
 {
-	return pos*16/static_cast<float>(1u<<m_regs.defs.CHOPCONF.mres)*static_cast<float>(cfg.uiStepsPerMM);
+	return pos*static_cast<float>(cfg.uiFullStepsPerMM); // Convert pos to steps, we always work in the full 256 microstep workspace.
 }

--- a/parts/components/TMC2130.h
+++ b/parts/components/TMC2130.h
@@ -51,9 +51,10 @@ class TMC2130: public SPIPeripheral, public Scriptable
             _IRQ(POSITION_OUT,      ">tmc2130.pos_out")
         #include "IRQHelper.h"
 
-        struct TMC2130_cfg_t {
+        using TMC2130_cfg_t = struct
+		{
             bool bInverted {false};
-            uint16_t uiStepsPerMM {100};
+            uint16_t uiFullStepsPerMM {100U*16U}; // This is FULL steps per mm, at maximum (256us) resolution.
             int16_t iMaxMM {200};
             float fStartPos{ 10.0};
             bool bHasNoEndStops {false};
@@ -212,8 +213,11 @@ class TMC2130: public SPIPeripheral, public Scriptable
         tmc2130_registers_t m_regs{};
 		std::atomic_char m_cAxis;
 		bool m_bStall = false;
+		uint32_t m_uiStepIncrement = 1;
 
 		// Position helpers
 		float StepToPos(int32_t step);
 		int32_t PosToStep(float step);
+
+		inline uint32_t GetStepDivisor() { return 256U>>m_regs.defs.CHOPCONF.mres; }
 };

--- a/utility/GLPrint.cpp
+++ b/utility/GLPrint.cpp
@@ -133,7 +133,7 @@ void GLPrint::NewCoord(float fX, float fY, float fZ, float fE)
 		// that's going to be disposable once this changes to a geometry or normal shader instead of the current implemetnation
 		// so I'm going to leave it as is for now.
 		std::vector<float> fCross = {0,0,0}, fA = {0,0,0} ,fB = {0,-0.002,0};
-		auto itPrev = m_fvNorms.end()-2;
+		auto itPrev = m_fvNorms.end()-3;
 		std::transform(itPrev, itPrev+3, vfPos.data(), fA.data(), std::minus<float>()); // Length from p->curr
 		CrossProduct(fA,fB,{fCross.data(),3});
 		Normalize({fCross.data(),3});
@@ -212,7 +212,7 @@ void GLPrint::Draw()
 			{
 				glMaterialfv(GL_FRONT_AND_BACK,GL_AMBIENT_AND_DIFFUSE,fY.data());
 				glBegin(GL_LINES);
-					glVertex3fv(&*(m_fvDraw.end()-2));
+					glVertex3fv(&*(m_fvDraw.end()-3));
 					glVertex3fv(m_fExtrEnd.data());
 				glEnd();
 			}


### PR DESCRIPTION
### Description

Changes the chopconf MRES handling to be easier to understand

### Behaviour/ Breaking changes

MRES no longer alters the bounds of the motor. Instead, we always work in the "maximum" microstep resolution of the driver, and increment the internal step count by 2^mres.

Motor steps per MM for TMC drivers is now input as the steps/mm if the driver was operating at full resolution, not the Marlin/M92 value.

### Have you tested the changes?

MMU now behaves as expected, main printer still moves as it should and the TMC automated test still works as expected.

### Other

Also fixed a nasty OOB bug in GLPrint.

### Linked issues:

 - fixes #223 
