### PR TITLE
Avoid reallocating vectors with every push_back

### DIFF
--- a/utility/GLPrint.h
+++ b/utility/GLPrint.h
@@ -73,6 +73,11 @@ class GLPrint
 
 		std::vector<int16_t> m_iStepsPerMM = {0,0,0};
 
+		// pre-allocation size for the vectors - saves a lot of CPU cycles
+		// when adding items into vectors (the vector will not get reallocated with every insertion)
+		static constexpr size_t VectorPrealoc = 2000000; // 2M items
+		static constexpr size_t VectorPrealoc3 = 3*VectorPrealoc; // 6M items
+
 		std::vector<int> m_ivStart, m_ivTStart;
 		std::vector<int> m_ivCount, m_ivTCount;
 		std::vector<float> m_fvDraw, m_fvNorms;


### PR DESCRIPTION
### Description

Avoid reallocating vectors with every push_back +avoid using std::vector when not necessary (replace with std::array if possible).

Constants VectorPrealoc and VectorPrealoc3 serve as initial preallocated size of the vectors, may be fine tuned for balanced usage of RAM.

There is much more space for optimization, but this one really brought the biggest benefit.

### Behaviour/ Breaking changes

Removes lagging of recalculation of extrusion visualization (3d extrusion, Quad_HR)

### Have you tested the changes?

Yes, I did 2 prints with extrusion visualization and compared to previous state. Each print took roughly 1 hour. The lagging disappeared, the rendering is visibly faster.

### Linked issues:

#114 