### PR TITLE
Enable simulation of nonlinear TMC+motor on X,Y,E

### DIFF
--- a/MK404.cpp
+++ b/MK404.cpp
@@ -297,7 +297,6 @@ int main(int argc, char *argv[])
 	SwitchArg argColourE("", "colour-extrusion", "Colours extrusion by width (for advanced step/extrusion debugging.", cmd, false);
 	SwitchArg argBootloader("b","bootloader","Run bootloader on first start instead of going straight to the firmware.",cmd);
 	SwitchArg argMD("","markdown","Used to auto-generate the items in refs/ as markdown",cmd);
-	SwitchArg arg3D("", "3d-extrusion", "Visualize with 3D extrusions (can be GPU intensive for large prints)", cmd);
 
 	std::vector<string> vstrPrinters = PrinterFactory::GetModels();
 	ValuesConstraint<string> vcAllowed(vstrPrinters);

--- a/utility/GLPrint.cpp
+++ b/utility/GLPrint.cpp
@@ -103,8 +103,14 @@ uint32_t GLPrint::GetAdjustedStep(uint32_t uiStep)
 	// }
 }
 
-void GLPrint::OnEStep(const uint32_t& uiE)
+void GLPrint::OnEStep(const uint32_t& uiE1)
 {
+	uint32_t uiE;
+#ifdef NONLINEAR_E
+	uiE = GetAdjustedStep(uiE1);
+#else
+	uiE = uiE1;
+#endif
 	m_uiE = uiE;
 	if (m_bFirst) // First cycle/extrusion.
 	{

--- a/utility/GLPrint.cpp
+++ b/utility/GLPrint.cpp
@@ -103,14 +103,9 @@ uint32_t GLPrint::GetAdjustedStep(uint32_t uiStep)
 	// }
 }
 
-void GLPrint::OnEStep(const uint32_t& uiE1)
+void GLPrint::OnEStep(const uint32_t& value)
 {
-	uint32_t uiE;
-#ifdef NONLINEAR_E
-	uiE = GetAdjustedStep(uiE1);
-#else
-	uiE = uiE1;
-#endif
+	uint32_t uiE = m_bNLE ? GetAdjustedStep(value) : value;
 	m_uiE = uiE;
 	if (m_bFirst) // First cycle/extrusion.
 	{

--- a/utility/GLPrint.h
+++ b/utility/GLPrint.h
@@ -29,10 +29,6 @@
 #include <tuple>
 #include <vector>  // for vector
 
-#define NONLINEAR_X
-#define NONLINEAR_Y
-#define NONLINEAR_E
-
 class GLPrint
 {
 	public:
@@ -49,24 +45,25 @@ class GLPrint
 	// Functions to receive new coordinate updates from your simulated printer's stepper drivers.
 
 	// Swap these two to enable simulated nonlinearity on X.
-#ifdef NONLINEAR_X
-	inline void OnXStep(const uint32_t &value) { m_uiX = GetAdjustedStep(value);}
-#else
-	inline void OnXStep(const uint32_t &value) { m_uiX = value;}
-#endif
 
-#ifdef NONLINEAR_Y
-	inline void OnYStep(const uint32_t &value) { m_uiY = GetAdjustedStep(value);}
-#else
-	inline void OnYStep(const uint32_t &value) { m_uiY = value;}
-#endif
-	inline void OnZStep(const uint32_t &value) { m_uiZ = value;}
+	inline void OnXStep(const uint32_t &value) { m_uiX = m_bNLX ? GetAdjustedStep(value) : value;}
+
+	inline void OnYStep(const uint32_t &value) { m_uiY = m_bNLY ? GetAdjustedStep(value) : value;}
+
+	inline void OnZStep(const uint32_t &value) { m_uiZ = m_bNLZ ? GetAdjustedStep(value) : value;}
+
 	void OnEStep(const uint32_t &value);
 
 	inline void SetStepsPerMM(int16_t iX, int16_t iY, int16_t iZ, int16_t iE)
 	{
 		m_iStepsPerMM = {iX, iY, iZ, iE};
 	}
+
+	// Enable/disable NL behaviour. (ab)use assignment returns for return val.
+	inline bool ToggleNLX() { return m_bNLX = !m_bNLX;}
+	inline bool ToggleNLY() { return m_bNLY = !m_bNLY;}
+	inline bool ToggleNLZ() { return m_bNLZ = !m_bNLZ;}
+	inline bool ToggleNLE() { return m_bNLE = !m_bNLE;}
 
 	private:
 
@@ -103,7 +100,7 @@ class GLPrint
 		bool m_bFirst = true;
 		float m_fLastERate = 0;
 		const float m_fColR, m_fColG, m_fColB;
-		std::atomic_bool m_bExtruding = {false};
+		std::atomic_bool m_bExtruding = {false}, m_bNLX {false}, m_bNLY {false}, m_bNLZ {false}, m_bNLE {false};
 		std::vector<std::tuple<uint32_t,uint32_t,uint32_t>> m_vPath;
 
 		std::mutex m_lock;

--- a/utility/GLPrint.h
+++ b/utility/GLPrint.h
@@ -29,6 +29,10 @@
 #include <tuple>
 #include <vector>  // for vector
 
+#define NONLINEAR_X
+#define NONLINEAR_Y
+#define NONLINEAR_E
+
 class GLPrint
 {
 	public:
@@ -45,10 +49,17 @@ class GLPrint
 	// Functions to receive new coordinate updates from your simulated printer's stepper drivers.
 
 	// Swap these two to enable simulated nonlinearity on X.
-//	inline void OnXStep(const uint32_t &value) { m_uiX = GetAdjustedStep(value);}
+#ifdef NONLINEAR_X
+	inline void OnXStep(const uint32_t &value) { m_uiX = GetAdjustedStep(value);}
+#else
 	inline void OnXStep(const uint32_t &value) { m_uiX = value;}
+#endif
 
+#ifdef NONLINEAR_Y
+	inline void OnYStep(const uint32_t &value) { m_uiY = GetAdjustedStep(value);}
+#else
 	inline void OnYStep(const uint32_t &value) { m_uiY = value;}
+#endif
 	inline void OnZStep(const uint32_t &value) { m_uiZ = value;}
 	void OnEStep(const uint32_t &value);
 

--- a/utility/MK3SGL.cpp
+++ b/utility/MK3SGL.cpp
@@ -69,6 +69,10 @@ MK3SGL::MK3SGL(const std::string &strModel, bool bMMU, Printer *pParent):Scripta
 	RegisterActionAndMenu("ResetCamera","Resets camera view to default",ActResetView);
 	RegisterAction("MouseBtn", "Simulates a mouse button (# = GL button enum, gl state,x,y)", ActMouse, {ArgType::Int,ArgType::Int,ArgType::Int,ArgType::Int});
 	RegisterAction("MouseMove", "Simulates a mouse move (x,y)", ActMouseMove, {ArgType::Int,ArgType::Int});
+	RegisterActionAndMenu("NonLinearX", "Toggle motor nonlinearity on X", ActNonLinearX);
+	RegisterActionAndMenu("NonLinearY", "Toggle motor nonlinearity on Y", ActNonLinearY);
+	RegisterActionAndMenu("NonLinearZ", "Toggle motor nonlinearity on Z", ActNonLinearZ);
+	RegisterActionAndMenu("NonLinearE", "Toggle motor nonlinearity on E", ActNonLinearE);
 
 	RegisterKeyHandler('`', "Reset camera view to default");
 	RegisterKeyHandler('n',"Toggle Nozzle-Cam Mode");
@@ -269,6 +273,18 @@ Scriptable::LineStatus MK3SGL::ProcessAction(unsigned int iAct, const std::vecto
 			return LineStatus::Finished;
 		case ActClear:
 			ClearPrint();
+			return LineStatus::Finished;
+		case ActNonLinearX: // NOTE: we only do this for T0 for now. Not hard to extend with for(auto &print: m_vPrints)...
+			std::cout << "Nonlinear X: " << std::to_string(m_Print.ToggleNLX()) << '\n';
+			return LineStatus::Finished;
+		case ActNonLinearY:
+			std::cout << "Nonlinear Y: " << std::to_string(m_Print.ToggleNLY()) << '\n';
+			return LineStatus::Finished;
+		case ActNonLinearZ: // NOTE: we only do this for T0 for now. Not hard to extend with for(auto &print: m_vPrints)...
+			std::cout << "Nonlinear Z: " << std::to_string(m_Print.ToggleNLZ()) << '\n';
+			return LineStatus::Finished;
+		case ActNonLinearE:
+			std::cout << "Nonlinear E: " << std::to_string(m_Print.ToggleNLE()) << '\n';
 			return LineStatus::Finished;
 		default:
 			return LineStatus::Unhandled;

--- a/utility/MK3SGL.h
+++ b/utility/MK3SGL.h
@@ -188,7 +188,11 @@ class MK3SGL: public BasePeripheral, public Scriptable, private IKeyClient
 			ActToggleNCam,
 			ActResetView,
 			ActMouse,
-			ActMouseMove
+			ActMouseMove,
+			ActNonLinearX,
+			ActNonLinearY,
+			ActNonLinearZ,
+			ActNonLinearE
 		};
 
 		static MK3SGL *g_pMK3SGL;


### PR DESCRIPTION
### Description

Enables simulation of nonlinear TMC+motor on X,Y,E. When enabled, extrusion visualization tries to simulate nonlinear behavior of TMC+motor on the corresponding axis (or a set of axes). 

### Behaviour/ Breaking changes

In this PR the nonlinearity is enabled by default - it is up to @vintagepc to decide whether this behavior should be enabled or disabled by default. If not, please comment out:

```
#define NONLINEAR_X
#define NONLINEAR_Y
#define NONLINEAR_E
```
### Have you tested the changes?

Yes, simulating nonlinear behavior of TMC+motor on each of the axes has revealed serious print artefacts including the infamous "issue 602".

### Other

Possible future improvements:
- add a command line switch to enable/disable nonlinearity on an axis
- add a key shortcut to enable/disable nonlinearity - this may simplify investigation of artefacts a bit

### Linked issues:

Issue #114