### PR TITLE
Patch A4982 step-position conversion functions

### DIFF
--- a/parts/boards/Test_Board.cpp
+++ b/parts/boards/Test_Board.cpp
@@ -131,7 +131,7 @@ namespace Boards
 
 		m_Allg.GetConfig().iMaxMM = 20;
 		m_Allg.GetConfig().fStartPos = 10.f;
-		m_Allg.GetConfig().uiStepsPerMM = 10*16;
+		m_Allg.GetConfig().uiStepsPerMM = 10*16; // Needs to be at the full step count for 16ms, regardless of actual MS setting.
 		AddHardware(m_Allg);
 		TryConnect(X_DIR_PIN, &m_Allg, A4982::DIR_IN);
 		TryConnect(X_STEP_PIN, &m_Allg, A4982::STEP_IN);

--- a/parts/boards/Test_Board.cpp
+++ b/parts/boards/Test_Board.cpp
@@ -131,7 +131,7 @@ namespace Boards
 
 		m_Allg.GetConfig().iMaxMM = 20;
 		m_Allg.GetConfig().fStartPos = 10.f;
-		m_Allg.GetConfig().uiStepsPerMM = 10;
+		m_Allg.GetConfig().uiStepsPerMM = 10*16;
 		AddHardware(m_Allg);
 		TryConnect(X_DIR_PIN, &m_Allg, A4982::DIR_IN);
 		TryConnect(X_STEP_PIN, &m_Allg, A4982::STEP_IN);

--- a/parts/components/A4982.cpp
+++ b/parts/components/A4982.cpp
@@ -292,11 +292,11 @@ void A4982::Init(struct avr_t * avr)
 float A4982::StepToPos(int32_t step)
 {
 	// Position is always in 16ths of a step.
-	return static_cast<float>(step)/16.f/static_cast<float>(m_cfg.uiStepsPerMM);
+	return static_cast<float>(step)/static_cast<float>(m_cfg.uiStepsPerMM);
 }
 
 int32_t A4982::PosToStep(float pos)
 {
 	// Position is always 16ths of a step...
-	return pos*16.f*static_cast<float>(m_cfg.uiStepsPerMM);
+	return pos*static_cast<float>(m_cfg.uiStepsPerMM);
 }


### PR DESCRIPTION
### Description
Fixes steps/mm being calculated incorrectly on miniRambo based boards.

### Behaviour/ Breaking changes
None

### Have you tested the changes?
Tested Prusa_MK2_mR13 variant with two different microstepping configurations. Both worked as expected. 

### Linked issues:
closes #253 

![image](https://user-images.githubusercontent.com/17808203/95605251-5939d580-0a61-11eb-8b88-eef071015540.png)
![image](https://user-images.githubusercontent.com/17808203/95606199-ab2f2b00-0a62-11eb-9c32-11af0e4b6824.png)

