### PR TITLE
Fix IRSensor if ADC isn't running

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Cache permissions
       run: sudo chmod -R 744 packages
 
-    - uses: openrndr/setup-opengl@21a61c3
+    - uses: openrndr/setup-opengl@v1.1
     - run: |
         xvfb-run glxinfo
         ls -l
@@ -148,7 +148,7 @@ jobs:
     - name: Cache permissions
       run: sudo chmod -R 744 packages
 
-    - uses: openrndr/setup-opengl@21a61c3
+    - uses: openrndr/setup-opengl@v1.1
     - run: |
         xvfb-run glxinfo
         ls -l

--- a/parts/ADCPeripheral.h
+++ b/parts/ADCPeripheral.h
@@ -40,6 +40,7 @@ class ADCPeripheral: public BasePeripheral
             BasePeripheral::_Init(avr,p);
 
             m_uiMux = uiADC;
+			m_bConnected = true;
 
 	        RegisterNotify(C::ADC_TRIGGER_IN, MAKE_C_CALLBACK(ADCPeripheral,_OnADCRead<C>), this);
 
@@ -68,6 +69,8 @@ class ADCPeripheral: public BasePeripheral
                 RaiseIRQFloat(C::DIGITAL_OUT,(m_pIrq.begin() + C::DIGITAL_OUT)->flags | IRQ_FLAG_FLOATING);
 			}
         };
+
+		inline bool IsConnected() { return m_bConnected; }
     private:
         template<class C>
         void _OnADCRead(struct avr_irq_t * irq, uint32_t value)
@@ -95,4 +98,6 @@ class ADCPeripheral: public BasePeripheral
         uint8_t m_uiMux = 0;
 
         uint32_t m_uiLast = 0;
+
+		bool m_bConnected = false;
 };

--- a/parts/ADCPeripheral.h
+++ b/parts/ADCPeripheral.h
@@ -51,6 +51,23 @@ class ADCPeripheral: public BasePeripheral
                 ConnectTo(C::ADC_VALUE_OUT, dst);
             }
          };
+
+		template<class C>
+        void _SyncDigitalIRQ(uint32_t uiVOut)
+        {
+            if (uiVOut>2200) // 2.2V, logic H
+			{
+                RaiseIRQ(C::DIGITAL_OUT,1);
+			}
+            else if (uiVOut < 800) // 0.8v. L
+			{
+                RaiseIRQ(C::DIGITAL_OUT,0);
+			}
+            else
+			{
+                RaiseIRQFloat(C::DIGITAL_OUT,(m_pIrq.begin() + C::DIGITAL_OUT)->flags | IRQ_FLAG_FLOATING);
+			}
+        };
     private:
         template<class C>
         void _OnADCRead(struct avr_irq_t * irq, uint32_t value)
@@ -73,23 +90,6 @@ class ADCPeripheral: public BasePeripheral
             RaiseIRQ(C::ADC_VALUE_OUT,uiVal);
             _SyncDigitalIRQ<C>(uiVal);
             m_uiLast = uiVal;
-        };
-
-        template<class C>
-        void _SyncDigitalIRQ(uint32_t uiVOut)
-        {
-            if (uiVOut>2200) // 2.2V, logic H
-			{
-                RaiseIRQ(C::DIGITAL_OUT,1);
-			}
-            else if (uiVOut < 800) // 0.8v. L
-			{
-                RaiseIRQ(C::DIGITAL_OUT,0);
-			}
-            else
-			{
-                RaiseIRQFloat(C::DIGITAL_OUT,(m_pIrq.begin() + C::DIGITAL_OUT)->flags | IRQ_FLAG_FLOATING);
-			}
         };
 
         uint8_t m_uiMux = 0;

--- a/parts/components/IRSensor.cpp
+++ b/parts/components/IRSensor.cpp
@@ -142,7 +142,7 @@ void IRSensor::Toggle()
 void IRSensor::Set(IRState val)
 {
 	m_eCurrent = val;
-	if (!m_bADCRunning)
+	if (!m_bADCRunning && IsConnected())
 	{
 		_SyncDigitalIRQ<VoltageSrc>(GetCurrentValue());
 	}

--- a/parts/components/IRSensor.h
+++ b/parts/components/IRSensor.h
@@ -87,6 +87,9 @@ private:
 	// ADC read trigger
  	uint32_t OnADCRead(avr_irq_t *pIRQ, uint32_t value) override;
 
+	// Returns current value based on m_eCurrent
+	uint32_t GetCurrentValue();
+
 	// LUT for states to voltage readouts.
 	std::map<IRState,float> m_mIRVals =
 	{
@@ -101,4 +104,6 @@ private:
 
 	std::atomic_bool m_bExternal {false};
 	IRState m_eCurrent = IR_v4_NO_FILAMENT;
+
+	bool m_bADCRunning = false;
 };


### PR DESCRIPTION
### Description

Fixes a bug where the IRSensor digital IRQ does not update if the ADC isn't running

### Have you tested the changes?

Yes - IR sensor now toggles as expected with firmware that does not start the ADC running. 