### PR TITLE
Add UART1 aka RPi port to Einsy and MK3/s

### DIFF
--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -51,6 +51,7 @@ namespace Boards
 
 		AddSerialPty(&UART2,'2');
 		AddHardware(UART0);
+		AddHardware(UART1);
 
 		AddHardware(m_Mon0,'0');
 
@@ -197,6 +198,7 @@ namespace Boards
 		}
 
 		AddUARTTrace('0'); // External
+		AddUARTTrace('1'); // RPi port
 		AddUARTTrace('2'); // MMU/internal/P3
 
 		//avr_irq_register_notify(GetDIRQ(PAT_INT_PIN), MAKE_C_CALLBACK(EinsyRambo, DebugPin),this);

--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -54,6 +54,7 @@ namespace Boards
 		AddHardware(UART1);
 
 		AddHardware(m_Mon0,'0');
+		AddHardware(m_Mon1,'1');
 
 		// SD card
 		std::string strSD = GetSDCardFile();

--- a/parts/boards/EinsyRambo.h
+++ b/parts/boards/EinsyRambo.h
@@ -74,7 +74,7 @@ namespace Boards
 			RotaryEncoder encoder;
 			Button PowerPanic {"Power Panic",'p',"Triggers Power Panic line"};
 			Beeper m_buzzer;
-			uart_pty UART0, UART2;
+			uart_pty UART0, UART1, UART2;
 			SerialLineMonitor m_Mon0 = SerialLineMonitor("Serial0");
 			Thermistor tExtruder, tBed, tPinda, tAmbient;
 			Fan fExtruder {3300,'E'}, fPrint {5000,'P',true};

--- a/parts/boards/EinsyRambo.h
+++ b/parts/boards/EinsyRambo.h
@@ -76,6 +76,7 @@ namespace Boards
 			Beeper m_buzzer;
 			uart_pty UART0, UART1, UART2;
 			SerialLineMonitor m_Mon0 = SerialLineMonitor("Serial0");
+			SerialLineMonitor m_Mon1 = SerialLineMonitor("Serial1");
 			Thermistor tExtruder, tBed, tPinda, tAmbient;
 			Fan fExtruder {3300,'E'}, fPrint {5000,'P',true};
 			Heater hExtruder = {1.5,25.0,false,'H',30,250},

--- a/parts/printers/Prusa_MK3S.cpp
+++ b/parts/printers/Prusa_MK3S.cpp
@@ -162,6 +162,7 @@ void Prusa_MK3S::SetupHardware()
 	if (GetConnectSerial())
 	{
 		UART0.Connect('0');
+		UART0.Connect('1');
 	}
 
 	auto fcnSerial = [](avr_t *avr, avr_io_addr_t addr, uint8_t v, void * param)

--- a/parts/printers/Prusa_MK3S.cpp
+++ b/parts/printers/Prusa_MK3S.cpp
@@ -162,7 +162,7 @@ void Prusa_MK3S::SetupHardware()
 	if (GetConnectSerial())
 	{
 		UART0.Connect('0');
-		UART0.Connect('1');
+		UART1.Connect('1');
 	}
 
 	auto fcnSerial = [](avr_t *avr, avr_io_addr_t addr, uint8_t v, void * param)


### PR DESCRIPTION
### Description

Add UART1 aka RPi port for Einsy and MK3/s

### Behaviour/ Breaking changes

Adds /tmp/simavr-uart1

### Have you tested the changes? YES

- Start MK404 Prusa_MK3* with `-s` option 
- Try to connect with Octoprint to /tmp/simavr-uart0
  - Result connection established
- Try to connect with Octoprint to /tmp/simavr-uart1
  - Result connection fails
- Change in MK3/s under Settings -> RPI port to [On]
- Try to connect with Octoprint to /tmp/simavr-uart0
  - Result connection fails
- Try to connect with Octoprint to /tmp/simavr-uart1
  - Result connection established
