### PR TITLE
Stop WaitForText() check if there is no net change

### DIFF
--- a/parts/components/HD44780.cpp
+++ b/parts/components/HD44780.cpp
@@ -233,8 +233,11 @@ uint32_t HD44780::OnDataReady()
 			{
 				int iPos =m_uiCursor - m_lineOffsets.at(i);
 				std::string &line = m_vLines[i];
-				line[iPos] = m_uiDataPins;
-				m_uiLineChg |= 1U<<i;
+				if (line[iPos] != m_uiDataPins) // Only if the contents change!
+				{
+					line[iPos] = m_uiDataPins;
+					m_uiLineChg |= 1U<<i;
+				}
 			}
 		}
 		TRACE(printf("hd44780_write_data %02x (%c) to %02x\n", m_uiDataPins, m_uiDataPins, m_uiCursor));


### PR DESCRIPTION
### Description

Minor issue with LCD waitForText adding a lot of overhead due to display refreshes

### Behaviour/ Breaking changes

Changed so that the "Line changed" flag is not updated if the character is udpated to the same thing. 

### Have you tested the changes?

N/A

### Other

Might speed up the build automated tests. 

### Linked issues:

 - Please list issue numbers related to your change, and use closing keywords if appropriate.
