### PR TITLE
Fix multipage xflash load

### DIFF
--- a/parts/Board.cpp
+++ b/parts/Board.cpp
@@ -339,7 +339,12 @@ namespace Boards {
 				gsl::span<uint8_t> chunk0 {pChunks[0].data, pChunks[0].size};
 				uint32_t uiFWStart = pChunks[0].baseaddr;
 				if (iCount > 1) {
-					OnExtraHexChunk({pChunks[1].data,pChunks[1].size});
+					pChunks[1].baseaddr = 0; // Want to start at 0 in the flash chip, but after hex read this is end-of-firmware.
+					gsl::span<ihex_chunk_t> spanChunks {pChunks, gsl::narrow<uint32_t>(iCount)};
+					for (int i=1; i<iCount; i++)
+					{
+						OnExtraHexChunk({spanChunks.at(i).data,spanChunks.at(i).size},spanChunks.at(i).baseaddr);
+					}
 				}
 				std::cout << "Loaded "  << chunk0.size_bytes() << " bytes from HEX file: " << strFW << '\n';
 				gsl::span<uint8_t> flash {m_pAVR->flash, m_pAVR->flashend};

--- a/parts/Board.h
+++ b/parts/Board.h
@@ -112,7 +112,7 @@ namespace Boards
 			virtual void OnAVRCycle(){};
 
 			// For boards that can handle extra chunks in the hex (language)
-			virtual void OnExtraHexChunk(gsl::span<uint8_t> /*chunk*/){};
+			virtual void OnExtraHexChunk(gsl::span<uint8_t> /*chunk*/, uint32_t uiBase){};
 
 			void OnKeyPress(const Key& key) override;
 

--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -240,9 +240,9 @@ namespace Boards
 		sd_card.Unmount();
 	}
 
-	void EinsyRambo::OnExtraHexChunk(gsl::span<uint8_t> chunk)
+	void EinsyRambo::OnExtraHexChunk(gsl::span<uint8_t> chunk, uint32_t uiBase)
 	{
-		spiFlash.Load(chunk);
+		spiFlash.Load(chunk, uiBase);
 	}
 
 	void EinsyRambo::OnAVRReset()

--- a/parts/boards/EinsyRambo.h
+++ b/parts/boards/EinsyRambo.h
@@ -66,7 +66,7 @@ namespace Boards
 
 			void OnKeyPress(const Key& key) override;
 
-			void OnExtraHexChunk(gsl::span<uint8_t> chunk) override;
+			void OnExtraHexChunk(gsl::span<uint8_t> chunk, uint32_t uiBase) override;
 
 			static constexpr float fScale24v = 1.0f/26.097f; // Based on rSense voltage divider outputting 5v
 

--- a/parts/components/w25x20cl.cpp
+++ b/parts/components/w25x20cl.cpp
@@ -358,11 +358,11 @@ void w25x20cl::Load(const std::string &path)
 		Load();
 }
 
-void w25x20cl::Load(const gsl::span<uint8_t> data)
+void w25x20cl::Load(const gsl::span<uint8_t> data, uint32_t uiOffset)
 {
-	size_t bytes = std::min(m_flash.size_bytes(), data.size_bytes());
-	memcpy(m_flash.begin(), data.begin(), bytes);
-	std::cout << "Loaded " << std::to_string(bytes) << " from hex file to xflash\n";
+	size_t bytes = std::min(m_flash.size_bytes() - uiOffset, data.size_bytes());
+	memcpy(m_flash.begin() + uiOffset, data.begin(), bytes);
+	std::cout << "Loaded " << std::to_string(bytes) << " bytes from hex file to xflash\n";
 }
 
 void w25x20cl::Load()

--- a/parts/components/w25x20cl.h
+++ b/parts/components/w25x20cl.h
@@ -59,7 +59,7 @@ class w25x20cl:public SPIPeripheral, public Scriptable
 	void Load(const std::string &path);
 
 	// Loads from an array
-	void Load(const gsl::span<uint8_t> data);
+	void Load(const gsl::span<uint8_t> data, uint32_t uiOffset = 0);
 
 	// Reloads the current file.
 	void Load();


### PR DESCRIPTION
### Description

If the languages are more than 64K the hex file splits them into sections. 
Handle this appropriately and load the additional pages. 

### Behaviour/ Breaking changes

None - should fix larger language loads.

### Have you tested the changes?

Can confirm that locally prior to this fix the community languages list was empty. After the fix, "Nederlands" appears as expected. 

### Linked issues:

 - N/A, request by @3d-gussner 
