### PR TITLE
Hide skew-correct's "Lost X us!" messages by default

### DIFF
--- a/parts/Board.cpp
+++ b/parts/Board.cpp
@@ -474,11 +474,16 @@ namespace Boards {
 					auto tDiff = gsl::narrow<int64_t>(static_cast<uint64_t>(tWall)-tSim);
 					if (tDiff>1000000) // 1 ms
 					{
-						std::cout << "Lost " << std::to_string(tDiff/1000) << " us!\n";
 						if (tDiff>5000000) // If we lose more than 5ms, don't try to catch up.
 						{
+							if(m_pAVR->log > 1)
+								std::cout << "Skipping " << std::to_string(tDiff/1000) << " us!\n";
 							uiLost += tDiff;
+						} else if(m_pAVR->log > 2)
+						{
+							std::cout << "Lost " << std::to_string(tDiff/1000) << " us!\n";
 						}
+
 					}
 				}
 				// if (vsim.size()<10000)

--- a/parts/Board.cpp
+++ b/parts/Board.cpp
@@ -476,8 +476,13 @@ namespace Boards {
 					{
 						if (tDiff>5000000) // If we lose more than 5ms, don't try to catch up.
 						{
-							if(m_pAVR->log > 1)
+							if(m_pAVR->log > 1 || !m_bLostTimeLogged) {
+								if (!m_bLostTimeLogged) {
+									std::cout << "\033[1;31mWARNING: Your system cannot keep up in --skew-correct mode!\033[0m\n";
+									m_bLostTimeLogged = true;
+								}
 								std::cout << "Skipping " << std::to_string(tDiff/1000) << " us!\n";
+							}
 							uiLost += tDiff;
 						} else if(m_pAVR->log > 2)
 						{
@@ -534,7 +539,11 @@ namespace Boards {
 		// {
 		// 	std::cout << std::to_string(vdC.at(i)) << ',' << std::to_string(vwall.at(i)) << ',' << std::to_string(vsim.at(i)) << '\n';
 		// }
-
+		if (m_bLostTimeLogged) {
+			std::cout << "\033[1;31mYour system was not able to keep simulation time from falling behind wall time. \033[0m\n";
+			std::cout << "If this number is big and you had issues with --skew-correct and real-time simulation (e.g. klipper) it's probably not a simulator bug.\n";
+			std::cout << "Total time lost during simulation: " << std::to_string(uiLost/1000U) << "ms\n";
+		}
 		return nullptr;
 	};
 

--- a/parts/Board.h
+++ b/parts/Board.h
@@ -169,6 +169,8 @@ namespace Boards
 			std::atomic_bool m_bQuit = {false}, m_bReset = {false};
 			bool m_bIsPrimary = false, m_bCorrectSkew = false;
 
+			bool m_bLostTimeLogged = false;
+
 			pthread_t m_thread = 0;
 			const Wirings::Wiring &m_wiring;
 			std::string m_strBoard = "";


### PR DESCRIPTION
### Description

When enabling skew-correct, the "Lost X us!" messages can overwhelm the
output. Hide the message behind the verbosity switch.

A single -v switch now shows only uncompensated time, which is what
matters most.

-vv also shows the existing message as well.

### Behaviour/ Breaking changes

No breaking behavior AFAIK.

### Have you tested the changes?

Yes

### Other

n/a

### Linked issues:

none