### PR TITLE
Fix PINDA crash when probing nearby bed margins

### DIFF
--- a/parts/components/PINDA.cpp
+++ b/parts/components/PINDA.cpp
@@ -130,8 +130,10 @@ void PINDA::CheckTrigger()
 	}
 
     // Just calc the nearest MBL point and report it.
-    uint8_t iX = floor(((m_fPos[0] - m_fOffset[0])/255.0)*7);
-    uint8_t iY = floor(((m_fPos[1] - m_fOffset[1])/210.0)*7);
+	const float fMaxX = 255.;
+	const float fMaxY = 210.;
+	uint8_t iX = floor((std::min(fMaxX-1.f, std::max(0.f, m_fPos[0] - m_fOffset[0]))/fMaxX)*7);
+	uint8_t iY = floor((std::min(fMaxY-1.f, std::max(0.f, m_fPos[1] - m_fOffset[1]))/fMaxY)*7);
 
     float fZTrig = gsl::at(m_mesh.points,iX+(7*iY));
 

--- a/scripts/tests/test_PINDA.txt
+++ b/scripts/tests/test_PINDA.txt
@@ -21,6 +21,19 @@ Serial0::NextLineMustBe(PINE 00)
 PINDA::SetPos(0,0,4.8)
 TelHost::WaitFor(PINDA_>pinda.out,1)
 Serial0::NextLineMustBe(PINE 40)
+
+# check that probing outside the bed doesn't crash
+PINDA::SetMBLPoint(0,3.5);
+PINDA::SetPos(-1,-1,4.6)
+TelHost::WaitFor(PINDA_>pinda.out,0)
+PINDA::SetPos(-1,-1,4.5)
+TelHost::WaitFor(PINDA_>pinda.out,1)
+PINDA::SetMBLPoint(48,3.5);
+PINDA::SetPos(255,210,4.6)
+TelHost::WaitFor(PINDA_>pinda.out,0)
+PINDA::SetPos(255,210,4.5)
+TelHost::WaitFor(PINDA_>pinda.out,1)
+
 PINDA::ToggleSheet();
 PINDA::SetPos(0,0,0)
 TelHost::WaitFor(PINDA_>pinda.out,0)


### PR DESCRIPTION
### Description

Clamp probing coordinates to be always inside the mesh.

This is not correct when probing far away from the bed (PINDA shouldn't trigger at all), but for now this will do.

### Behaviour/ Breaking changes

None.

### Have you tested the changes?

Tests included.

### Linked issues:

Fixes #313