### PR TITLE
Misc fixes

### DIFF
--- a/parts/KeyController.cpp
+++ b/parts/KeyController.cpp
@@ -95,6 +95,11 @@ void KeyController::OnAVRCycle()
 
 	m_key.store(0);
 
+	if (key == '?') {
+		PrintKeys(false);
+		return;
+	}
+
 	if (m_mClients.count(key)>0)
 	{
 		std::vector<IKeyClient*>& vClients = m_mClients.at(key);

--- a/scripts/tests/test_lite_gfx_keys.txt
+++ b/scripts/tests/test_lite_gfx_keys.txt
@@ -1,6 +1,7 @@
 # This script just checks that the printer boots by looking for 'start' on the serial line.
 ScriptHost::SetTimeoutMs(10000)
 ScriptHost::SetQuitOnTimeout(1)
+KeyCtl::Key(?)
 Serial0::WaitForLine(READY)
 3DView::Snapshot(tests/snaps/GFXLiteKey01)
 KeyCtl::Key(n)


### PR DESCRIPTION
### Description

Minor features and fixes - a `?` hotkey and a null pointer dereference.

### Behaviour/ Breaking changes

- Prints key reference to console if user presses `?` key
-  Sim no longer crashes if holding C and trhe card unmounts while mid-read.

### Linked issues:

 - Fixes #323 
 - Fixes #324
