### PR TITLE
Update Codecov

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -227,7 +227,7 @@ jobs:
       uses: codecov/codecov-action@v2.1.0
       with: 
         # Comma-separated list of files to upload
-        files: parts/parts.info, ext1/ext1.info
+        files: ./parts/parts.info,./ext1/ext1.info
         # Specify whether or not CI build should fail if Codecov runs into an error during upload
         fail_ci_if_error: true
         # Comma-separated list, see the README for options and their usage


### PR DESCRIPTION
Closes #330

Change to codecov action instead of manually invoking the bash uploader.