### PR TITLE
Use consistent __attribute__((__packed__))

### DIFF
--- a/parts/I2CPeripheral.h
+++ b/parts/I2CPeripheral.h
@@ -63,7 +63,7 @@ class I2CPeripheral: public BasePeripheral
 				uint8_t writeRegAddr;
 				uint8_t isAddrRead :1; // Write bit on address. IDK if this is used given msgBits.isWrite.
 				uint8_t address :7;
-			}__attribute__ ((__packed__));
+			} __attribute__((__packed__));
 		};
 
 		using NativeI2CMsg_t = union NativeI2CMsg {
@@ -75,7 +75,7 @@ class I2CPeripheral: public BasePeripheral
 				uint8_t isWrite :1; // Write bit on address. IDK if this is used given msgBits.isWrite.
 				uint8_t address :7;
 				uint8_t data :8 ;
-			} __attribute__ ((__packed__));
+			} __attribute__((__packed__));
 		};
 
 		// I2C transaction handler.

--- a/parts/components/MCP23S17.h
+++ b/parts/components/MCP23S17.h
@@ -46,7 +46,7 @@ using mcp_reg_bank_1_t = struct mcp_reg_bank_1_t {
 			uint8_t SEQOP :1;
 			uint8_t MIRROR :1;
 			uint8_t BANK :1;
-		} __attribute__ ((__packed__)) IOCON;
+		} __attribute__((__packed__)) IOCON;
 	};
 	uint8_t GPPU;		//0x06
 	uint8_t INTF;		//0x07
@@ -119,7 +119,7 @@ class MCP23S17: public SPIPeripheral
 				uint8_t READ :1;
 				uint8_t HADDR :3;
 				uint8_t _FIXED :4;
-			} __attribute__ ((__packed__));
+			} __attribute__((__packed__));
 		} m_hdr = {0};
 
 		union {

--- a/parts/components/SDCard.h
+++ b/parts/components/SDCard.h
@@ -146,7 +146,7 @@ class SDCard:public SPIPeripheral, public Scriptable, private IKeyClient
 				unsigned int address :32;
 				Command cmd :6;
 				unsigned char :2; // Start/position
-			} __attribute__ ((__packed__)) bits;
+			} __attribute__((__packed__)) bits;
 			uint8_t bytes[6];
 		} m_CmdIn {.all = 0};
 
@@ -161,7 +161,7 @@ class SDCard:public SPIPeripheral, public Scriptable, private IKeyClient
 				uint32_t function :4;
 				uint32_t mio :1;
 
-			} __attribute__ ((__packed__)) bits;
+			} __attribute__((__packed__)) bits;
 		};
 
 		struct {

--- a/parts/components/TMC2130.h
+++ b/parts/components/TMC2130.h
@@ -116,7 +116,7 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
 				uint32_t data :32; // 32 bits of data
 				uint8_t address :7;
 				uint8_t RW :1;
-            } __attribute__ ((__packed__)) bitsIn;
+            } __attribute__((__packed__)) bitsIn;
             struct {
                 uint32_t data :32; // 32 bits of data
                 uint8_t reset_flag :1;
@@ -124,7 +124,7 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
                 uint8_t sg2 :1;
                 uint8_t standstill :1;
                 uint8_t :4; // unused
-            }  __attribute__ ((__packed__)) bitsOut;
+            }  __attribute__((__packed__)) bitsOut;
             uint8_t bytes[5] {0,0,0,0,0}; // Raw bytes as piped in/out by SPI.
         };
 
@@ -152,14 +152,14 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
                     uint8_t stop_enable :1;
                     uint8_t direct_mode         :1;
 					uint16_t :14;
-                }  __attribute__ ((__packed__)) GCONF;             // 0x00
+                }  __attribute__((__packed__)) GCONF;             // 0x00
                 struct                 // 0x01
                 {
                     uint8_t reset   :1;
                     uint8_t drv_err :1;
                     uint8_t uv_cp   :1;
 					uint32_t :29; // unused
-                }  __attribute__ ((__packed__)) GSTAT;
+                }  __attribute__((__packed__)) GSTAT;
                 uint32_t _unimplemented[2]; //0x02 - 0x03
                 struct                 // 0x04
                 {
@@ -168,7 +168,7 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
 					uint8_t         :1;  // unused
 					uint16_t        :16; // unused
 					uint8_t version :8;
-                }  __attribute__ ((__packed__)) IOIN;
+                }  __attribute__((__packed__)) IOIN;
                 uint32_t _unimplemented2[103]; //0x05 - 0x6B
 				struct                        //0x6C
 				{
@@ -189,7 +189,7 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
 					uint32_t dedge		:1;
 					uint32_t diss2g		:1;
 					uint32_t			:1;
-				} __attribute__ ((__packed__)) CHOPCONF;
+				} __attribute__((__packed__)) CHOPCONF;
                 uint32_t _unimplemented3[2]; //0x6D - 0x6E
                 struct                       //0x6F
                 {
@@ -206,7 +206,7 @@ class TMC2130: public SPIPeripheral, public Scriptable, public GLMotor
                     uint8_t ola         :1;
                     uint8_t olb         :1;
                     uint8_t stst        :1;
-                }  __attribute__ ((__packed__)) DRV_STATUS;
+                }  __attribute__((__packed__)) DRV_STATUS;
             }defs;
         };
 

--- a/parts/components/usb_types.h
+++ b/parts/components/usb_types.h
@@ -62,7 +62,7 @@ struct usb_device_descriptor {
     byte iProduct;              // Index of String Descriptor describing the product.
     byte iSerialNumber;         // Index of String Descriptor with the device's serial number.
     byte bNumConfigurations;    // Number of possible configurations.
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 struct usb_configuration_descriptor
 {
@@ -74,7 +74,7 @@ struct usb_configuration_descriptor
     byte iConfiguration;        // Index of String Descriptor describing the configuration.
     byte bmAttributes;          // Configuration characteristics.
     byte bMaxPower;             // Maximum power consumed by this configuration.
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 
 struct usb_interface_descriptor
@@ -88,4 +88,4 @@ struct usb_interface_descriptor
     byte bInterfaceSubClass;    // Subclass code (assigned by the USB-IF).
     byte bInterfaceProtocol;    // Protocol code (assigned by the USB-IF).  0xFF-Vendor specific.
     byte iInterface;            // Index of String Descriptor describing the interface.
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));

--- a/parts/components/usbip_types.h
+++ b/parts/components/usbip_types.h
@@ -31,7 +31,7 @@ struct usbip_usb_interface {
 	uint8_t bInterfaceSubClass;
 	uint8_t bInterfaceProtocol;
 	uint8_t padding;	/* alignment */
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 struct usbip_usb_device {
 	char path[USBIP_SYSFS_PATH_MAX];
@@ -51,7 +51,7 @@ struct usbip_usb_device {
 	uint8_t bConfigurationValue;
 	uint8_t bNumConfigurations;
 	uint8_t bNumInterfaces;
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 
 #define USBIP_PROTO_VERSION 0x111
@@ -66,33 +66,33 @@ struct usbip_op_common {
 #define USBIP_ST_NA 0x01
 	uint32_t status;
 
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 #define USBIP_OP_DEVLIST 0x05
 
 struct usbip_op_devlist_request {
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 struct usbip_op_devlist_reply {
 	uint32_t ndev;
 	/* followed by reply_extra[] */
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 struct usbip_op_devlist_reply_extra {
 	struct usbip_usb_device    udev;
 	struct usbip_usb_interface uinf[];
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 
 #define USBIP_OP_IMPORT 0x03
 struct usbip_op_import_request {
     char busid[USBIP_SYSFS_BUS_ID_SIZE];
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 struct usbip_op_import_reply {
     struct usbip_usb_device udev;
 //	struct usbip_usb_interface uinf[];
-} __attribute__((packed));
+} __attribute__((__packed__));
 
 struct usbip_common_hdr {
     uint32_t command;
@@ -100,7 +100,7 @@ struct usbip_common_hdr {
     uint32_t devid; // (busnum << 16) | devnum
     uint32_t direction;
     uint32_t ep;
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 #define USBIP_CMD_SUBMIT 0x0001
 #define USBIP_CMD_UNLINK 0x0002
@@ -117,7 +117,7 @@ struct usbip_cmd_submit {
     int32_t number_of_packets;
     int32_t interval;
     unsigned char setup[8];
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 /*
 +  Allowed transfer_flags  | value      | control | interrupt | bulk     | isochronous
@@ -139,7 +139,7 @@ struct usbip_ret_submit {
     int32_t number_of_packets;
     int32_t error_count;
     long long setup;
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 
 struct usbip_cmd_unlink {
@@ -149,7 +149,7 @@ struct usbip_cmd_unlink {
     int32_t pad3;
     int32_t pad4;
     long long pad5;
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 
 struct usbip_ret_unlink {
@@ -159,7 +159,7 @@ struct usbip_ret_unlink {
     int32_t pad3;
     int32_t pad4;
     long long pad5;
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));
 
 struct usbip_header {
     struct usbip_common_hdr hdr;
@@ -169,4 +169,4 @@ struct usbip_header {
         struct usbip_cmd_unlink unlink;
         struct usbip_ret_unlink retunlink;
     } u;
-} __attribute__ ((__packed__));
+} __attribute__((__packed__));


### PR DESCRIPTION
### Description

Code consistency. In some places `__attribute__((__packed__))` was used in others `__attribute__((packed))`. I can't find any documentation that supports the later version but it could possibly be old syntax that still works in gcc.

### Behaviour/ Breaking changes

No behavioural changes are expected.
