### PR TITLE
Remove the need to calculate sqrt by using squared distance

### DIFF
--- a/parts/components/PINDA.cpp
+++ b/parts/components/PINDA.cpp
@@ -35,7 +35,7 @@
 // This creates an inverted parabolic trigger zone above the cal point
 void PINDA::CheckTriggerNoSheet()
 {
-    float fEdistSquared = 100^2;
+    float fEdistSquared = 1000.f;
     bool bFound = false;
     //printf("PINDA: X: %f Y: %f\n", m_fPos[0], m_fPos[1]);
 	if (m_fPos[2]<10.f)
@@ -44,7 +44,7 @@ void PINDA::CheckTriggerNoSheet()
 		{
 			fEdistSquared = pow(m_fPos[0] - GetXYCalPoints().at(2*i),2)  +
 				pow(m_fPos[1] - GetXYCalPoints().at((2*i)+1),2);
-			if (fEdistSquared<(10^2))
+			if (fEdistSquared<(100.f)) // 10mm search radius (squared)
 			{
 				//printf("PINDA: squared distance : %f\n", fEdistSquared);
 				bFound = true;
@@ -56,7 +56,7 @@ void PINDA::CheckTriggerNoSheet()
     if (bFound)
     {
 		bool bHasSheet = m_XYCalType != XYCalMap::MK2;
-        float fTrigZ = (1.0*(1-fEdistSquared/(5^2))) + (bHasSheet? 3.0 : 0.0) ;
+        float fTrigZ = (1.0*(1-fEdistSquared/(25.f))) + (bHasSheet? 3.0 : 0.0) ;
         //printf("fTZ:%f fZ: %f\n",fTrigZ, this->fPos[2]);
         if (m_fPos[2]<=fTrigZ)
 		{

--- a/parts/components/PINDA.cpp
+++ b/parts/components/PINDA.cpp
@@ -44,7 +44,7 @@ void PINDA::CheckTriggerNoSheet()
 		{
 			fEdistSquared = pow(m_fPos[0] - GetXYCalPoints().at(2*i),2)  +
 				pow(m_fPos[1] - GetXYCalPoints().at((2*i)+1),2);
-			if (fEdistSquared<(100.f)) // 10mm search radius (squared)
+			if (fEdistSquared<100.f) // 10mm search radius (squared)
 			{
 				//printf("PINDA: squared distance : %f\n", fEdistSquared);
 				bFound = true;
@@ -56,7 +56,7 @@ void PINDA::CheckTriggerNoSheet()
     if (bFound)
     {
 		bool bHasSheet = m_XYCalType != XYCalMap::MK2;
-        float fTrigZ = (1.0*(1-fEdistSquared/(25.f))) + (bHasSheet? 3.0 : 0.0) ;
+        float fTrigZ = (1.0*(1-fEdistSquared/25.f)) + (bHasSheet? 3.0 : 0.0) ;
         //printf("fTZ:%f fZ: %f\n",fTrigZ, this->fPos[2]);
         if (m_fPos[2]<=fTrigZ)
 		{

--- a/parts/components/PINDA.cpp
+++ b/parts/components/PINDA.cpp
@@ -35,17 +35,18 @@
 // This creates an inverted parabolic trigger zone above the cal point
 void PINDA::CheckTriggerNoSheet()
 {
-    float fEdist = 100;
+    float fEdistSquared = 100^2;
     bool bFound = false;
     //printf("PINDA: X: %f Y: %f\n", m_fPos[0], m_fPos[1]);
 	if (m_fPos[2]<10.f)
 	{
 		for (auto i=0U; i<GetXYCalPoints().size()/2; i++)
 		{
-			fEdist = sqrt( pow(m_fPos[0] - GetXYCalPoints().at(2*i),2)  +
-				pow(m_fPos[1] - GetXYCalPoints().at((2*i)+1),2));
-			if (fEdist<10)
+			fEdistSquared = pow(m_fPos[0] - GetXYCalPoints().at(2*i),2)  +
+				pow(m_fPos[1] - GetXYCalPoints().at((2*i)+1),2);
+			if (fEdistSquared<(10^2))
 			{
+				//printf("PINDA: squared distance : %f\n", fEdistSquared);
 				bFound = true;
 				break;  // Stop as soon as we find a near cal point.
 			}
@@ -55,7 +56,7 @@ void PINDA::CheckTriggerNoSheet()
     if (bFound)
     {
 		bool bHasSheet = m_XYCalType != XYCalMap::MK2;
-        float fTrigZ = (1.0*(1-pow(fEdist/5,2))) + (bHasSheet? 3.0 : 0.0) ;
+        float fTrigZ = (1.0*(1-fEdistSquared/(5^2))) + (bHasSheet? 3.0 : 0.0) ;
         //printf("fTZ:%f fZ: %f\n",fTrigZ, this->fPos[2]);
         if (m_fPos[2]<=fTrigZ)
 		{


### PR DESCRIPTION
### Description

Minor performance tweak. When doing distance comparisons (c^2 = a^2+b^2), you can calculate c < 10, or you can do c^2 < 100.

### Behaviour/ Breaking changes

Expect the same behaviour, and probably no noticeable performance gain, but still...

### Have you tested the changes?

Yes, seems to work with MK3 as before.
