### PR TITLE
Implement commandline option to enable/disable softPWM #345

### DIFF
--- a/MK404.cpp
+++ b/MK404.cpp
@@ -21,11 +21,11 @@
  */
 
 #include "Config.h"
+#include "EnabledType.h"
 #include "FatImage.h"                 // for FatImage
 #include "KeyController.h"
 #include "Macros.h"
 #include "PrintVisualType.h"
-#include "EnabledType.h"
 #include "Printer.h"                  // for Printer, Printer::VisualType
 #include "PrinterFactory.h"           // for PrinterFactory
 #include "ScriptHost.h"               // for ScriptHost

--- a/MK404.cpp
+++ b/MK404.cpp
@@ -329,6 +329,9 @@ int main(int argc, char *argv[])
 	ValueArg<string> argSD("","sdimage","Use the given SD card .img file instead of the default", false ,"", "filename.img", cmd);
 	SwitchArg argScriptHelp("","scripthelp", "Prints the available scripting commands for the current printer/context",cmd, false);
 	ValueArg<string> argScript("","script","Execute the given script. Use --scripthelp for syntax.", false ,"", "filename.txt", cmd);
+	std::vector<string> vstrEnabled = EnabledType::GetOpts();
+	ValuesConstraint<string> vcEnabledOpts(vstrEnabled);
+	ValueArg<string> argSoftPWM("p","softPWM","enable/disable software PWM (currently only valid for MK2)",false,"",&vcEnabledOpts,cmd);
 	SwitchArg argNoHacks("n","no-hacks","Disable any special hackery that might have been implemented for a board to run its manufacturer firmware, e.g. if you want to run stock marlin and have issues. Effects depend on the board and firmware.",cmd);
 	SwitchArg argMute("m","mute","Tell a printer to mute any audio it may produce.", cmd);
 	SwitchArg argMarlin("","marlin","Synonym for --no-hacks",cmd,false);
@@ -345,9 +348,6 @@ int main(int argc, char *argv[])
 	ValueArg<string> argGfx("g","graphics","Whether to enable fancy (advanced) or lite (minimal advanced) visuals. If not specified, only the basic 2D visuals are shown.",false,"lite",&vcGfxAllowed, cmd);
 	ValueArg<string> argFW("f","firmware","hex/afx/elf Firmware file to load (default MK3S.afx)",false,"MK3S.afx","filename", cmd);
 	ValueArg<string> argFW2("F","firmware2","secondary hex/afx/elf Firmware file to load to MMU, if present (default MM-control-01.hex)",false,"MM-control-01.hex","filename", cmd);
-	std::vector<string> vstrEnabled = EnabledType::GetOpts();
-	ValuesConstraint<string> vcEnabledOpts(vstrEnabled);
-	ValueArg<string> argSoftPWM("p","softPWM","enable/disable software PWM (currently only valid for MK2)",false,"",&vcEnabledOpts,cmd);
 	std::vector<string> vstrExts = PrintVisualType::GetOpts();
 	ValuesConstraint<string> vcPrintOpts(vstrExts);
 	ValueArg<string> argExtrusion("","extrusion","Set Print visual type. HR options create a LOT of triangles, do not use for large prints!",false, "Line", &vcPrintOpts, cmd);

--- a/MK404.cpp
+++ b/MK404.cpp
@@ -25,6 +25,7 @@
 #include "KeyController.h"
 #include "Macros.h"
 #include "PrintVisualType.h"
+#include "EnabledType.h"
 #include "Printer.h"                  // for Printer, Printer::VisualType
 #include "PrinterFactory.h"           // for PrinterFactory
 #include "ScriptHost.h"               // for ScriptHost
@@ -344,6 +345,9 @@ int main(int argc, char *argv[])
 	ValueArg<string> argGfx("g","graphics","Whether to enable fancy (advanced) or lite (minimal advanced) visuals. If not specified, only the basic 2D visuals are shown.",false,"lite",&vcGfxAllowed, cmd);
 	ValueArg<string> argFW("f","firmware","hex/afx/elf Firmware file to load (default MK3S.afx)",false,"MK3S.afx","filename", cmd);
 	ValueArg<string> argFW2("F","firmware2","secondary hex/afx/elf Firmware file to load to MMU, if present (default MM-control-01.hex)",false,"MM-control-01.hex","filename", cmd);
+	std::vector<string> vstrEnabled = EnabledType::GetOpts();
+	ValuesConstraint<string> vcEnabledOpts(vstrEnabled);
+	ValueArg<string> argSoftPWM("p","softPWM","enable/disable software PWM (currently only valid for MK2)",false,"",&vcEnabledOpts,cmd);
 	std::vector<string> vstrExts = PrintVisualType::GetOpts();
 	ValuesConstraint<string> vcPrintOpts(vstrExts);
 	ValueArg<string> argExtrusion("","extrusion","Set Print visual type. HR options create a LOT of triangles, do not use for large prints!",false, "Line", &vcPrintOpts, cmd);
@@ -398,6 +402,7 @@ int main(int argc, char *argv[])
 	m_bTestMode = (argModel.getValue()=="Test_Printer") | argTest.isSet();
 
 	Config::Get().SetLCDScheme(argLCDSCheme.getValue());
+	Config::Get().SetSoftPWM(EnabledType::GetNameToType().at(argSoftPWM.getValue()));
 	Config::Get().SetExtrusionMode(PrintVisualType::GetNameToType().at(argExtrusion.getValue()));
 	Config::Get().SetColourE(argColourE.isSet());
 	Config::Get().SetFW2(argFW2.getValue());

--- a/parts/printers/Prusa_MK2_13.cpp
+++ b/parts/printers/Prusa_MK2_13.cpp
@@ -186,10 +186,10 @@ void Prusa_MK2_13::SetupHardware()
 
 	switch (Config::Get().GetSoftPWM())
 	{
-		case EnabledType::Enabled:
+		case EnabledType::Type_t::Enabled:
 			hBed.SetSoftPWM(true);
 			break;
-		case EnabledType::Disabled:
+		case EnabledType::Type_t::Disabled:
 			hBed.SetSoftPWM(false);
 			break;
 		default:

--- a/parts/printers/Prusa_MK2_13.cpp
+++ b/parts/printers/Prusa_MK2_13.cpp
@@ -184,6 +184,17 @@ void Prusa_MK2_13::SetupHardware()
 
 	SetupPINDA();
 
+	switch (Config::Get().GetSoftPWM())
+	{
+		case EnabledType::Enabled:
+			hBed.SetSoftPWM(true);
+			break;
+		case EnabledType::Disabled:
+			hBed.SetSoftPWM(false);
+			break;
+		default:
+			break;
+	}
 	if (GetConnectSerial())
 	{
 		UART0.Connect('0');

--- a/utility/Config.h
+++ b/utility/Config.h
@@ -53,8 +53,8 @@ class Config
 		inline void SetDebugCore(bool bVal){ m_bDebugCore = bVal;}
 		inline bool GetDebugCore(){ return m_bDebugCore;}
 
-		inline void SetSoftPWM(unsigned int iVal){ m_SoftPWM = iVal; }
-		inline unsigned int GetSoftPWM(){ return m_SoftPWM; }
+		inline void SetSoftPWM(EnabledType::Type_t val){ m_SoftPWM = val; }
+		inline EnabledType::Type_t GetSoftPWM(){ return m_SoftPWM; }
 
 		// Secondary firmware?
 		inline void SetFW2(std::string strName){ m_strSecFW = std::move(strName);}
@@ -67,5 +67,5 @@ class Config
 		uint8_t m_iScheme = 0;
 		bool m_bDebugCore = false;
 		std::string m_strSecFW = "MM-control-01.hex";
-		unsigned int m_SoftPWM = false;
+		EnabledType::Type_t m_SoftPWM = EnabledType::Type_t::NotSet;
 };

--- a/utility/Config.h
+++ b/utility/Config.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include "PrintVisualType.h"
 #include "EnabledType.h"
+#include "PrintVisualType.h"
 
 class Config
 {
@@ -67,5 +67,5 @@ class Config
 		uint8_t m_iScheme = 0;
 		bool m_bDebugCore = false;
 		std::string m_strSecFW = "MM-control-01.hex";
-		unsigned int m_SoftPWM;
+		unsigned int m_SoftPWM = false;
 };

--- a/utility/Config.h
+++ b/utility/Config.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "PrintVisualType.h"
+#include "EnabledType.h"
 
 class Config
 {
@@ -52,6 +53,9 @@ class Config
 		inline void SetDebugCore(bool bVal){ m_bDebugCore = bVal;}
 		inline bool GetDebugCore(){ return m_bDebugCore;}
 
+		inline void SetSoftPWM(unsigned int iVal){ m_SoftPWM = iVal; }
+		inline unsigned int GetSoftPWM(){ return m_SoftPWM; }
+
 		// Secondary firmware?
 		inline void SetFW2(std::string strName){ m_strSecFW = std::move(strName);}
 		inline const std::string GetFW2(){ return m_strSecFW;}
@@ -63,5 +67,5 @@ class Config
 		uint8_t m_iScheme = 0;
 		bool m_bDebugCore = false;
 		std::string m_strSecFW = "MM-control-01.hex";
-
+		unsigned int m_SoftPWM;
 };

--- a/utility/EnabledType.h
+++ b/utility/EnabledType.h
@@ -1,0 +1,59 @@
+/*
+
+	EnabledType.h - Enum for the enabled/disabled options
+
+	Copyright 2020 VintagePC <https://github.com/vintagepc/>
+
+ 	This file is part of MK404.
+
+	MK404 is free software: you can redistribute it and/or modify
+	it under the terms of the GNU General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	MK404 is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
+
+	You should have received a copy of the GNU General Public License
+	along with MK404.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+class EnabledType
+{
+	public:
+
+		enum
+		{
+			NotSet,
+			Enabled,
+			Disabled
+		};
+
+		static inline std::vector<std::string> GetOpts()
+		{
+			static const std::vector<std::string> v {
+				"enabled",
+				"disabled"
+			};
+			return v;
+		}
+
+		static const std::map<std::string, unsigned int>& GetNameToType()
+		{
+			static const std::map<std::string, unsigned int> m {
+				{"",NotSet},
+				{"enabled",Enabled},
+				{"disabled",Disabled},
+			};
+			return m;
+		};
+
+};

--- a/utility/EnabledType.h
+++ b/utility/EnabledType.h
@@ -30,7 +30,7 @@ class EnabledType
 {
 	public:
 
-		enum
+		enum class Type_t
 		{
 			NotSet,
 			Enabled,
@@ -46,12 +46,12 @@ class EnabledType
 			return v;
 		}
 
-		static const std::map<std::string, unsigned int>& GetNameToType()
+		static const std::map<std::string, Type_t>& GetNameToType()
 		{
-			static const std::map<std::string, unsigned int> m {
-				{"",NotSet},
-				{"enabled",Enabled},
-				{"disabled",Disabled},
+			static const std::map<std::string, Type_t> m {
+				{"",Type_t::NotSet},
+				{"enabled",Type_t::Enabled},
+				{"disabled",Type_t::Disabled},
 			};
 			return m;
 		};


### PR DESCRIPTION
### Description

When testing 3.10.x firmware on MK2 simulated hardware, I'd like the option to enable software PWM.

### Behaviour/ Breaking changes

Adds the ability to use SoftPWM with the MK2 simulation. e.g 

`./MK404 Prusa_MK2_mR13 --softPWM enabled -f ...`

If not specified, and for other printer types, this will default to how its set to currently.

### Have you tested the changes?

 Works with the patched MK2 firmware, that relies on SoftPWM.

### Other

Only implemented for MK2, but if for example, someone wants to disable SoftPWM for MK3 this could be added.

### Linked issues:

#345
