### PR TITLE
Let ScriptHost read from stdio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,6 +545,7 @@ add_test(ext1_CW1 env ${TEST_EXPORT_PREFIX} ${TEST_XVFB_PREFIX} ./MK404 Prusa_CW
 add_test(ext1_CW1S env ${TEST_EXPORT_PREFIX} ${TEST_XVFB_PREFIX} ./MK404 Prusa_CW1S -f Prusa-CW1S-Firmware.hex --script ../scripts/tests/test_boot_cw1s.txt )
 add_test(ext1_CW1S_lite env ${TEST_EXPORT_PREFIX} ${TEST_XVFB_PREFIX} ./MK404 Prusa_CW1 -f Prusa-CW1-Firmware.hex -g lite --script ../scripts/tests/test_cw1_lite_gfx.txt )
 add_test(ext1_CW1S_full env ${TEST_EXPORT_PREFIX} ${TEST_XVFB_PREFIX} ./MK404 Prusa_CW1 -f Prusa-CW1-Firmware.hex -g fancy --script ../scripts/tests/test_cw1_full_gfx.txt )
+add_test(Internal_Scripting_stdio env ${TEST_EXPORT_PREFIX} ${TEST_XVFB_PREFIX} ../scripts/tests/extra_Scripting_stdio.py)
 
 
 # TODO- move these images out of parts and to their own ext2 dir...

--- a/MK404.cpp
+++ b/MK404.cpp
@@ -537,6 +537,10 @@ int main(int argc, char *argv[])
 	else
 	{
 		ScriptHost::Setup("",pBoard->GetAVR()->frequency);
+		if (!m_bTerminal)
+		{
+			ScriptHost::EnableStdio();
+		}
 	}
 
 	if (!bNoGraphics)

--- a/parts/ScriptHost.cpp
+++ b/parts/ScriptHost.cpp
@@ -164,10 +164,10 @@ void* ScriptHost::RunPty(void*)
 		FD_SET(fdPort, &fdsErr); //NOLINT
 		if ((iReadyRead = select(fdPort+1,&fdsIn, nullptr, &fdsErr,nullptr))<0)
 		{
-			std::cout << "Select ERR.\n";
+			std::cout << "Select ERR.\n"; //pragma: LCOV_EXCL_START
 			m_bPtyQuit = true;
 			break;
-		}
+		} // pragma: LCOV_EXCL_STOP
 		if (FD_ISSET(fdPort,&fdsIn)) //NOLINT
 		{
 			while ((iChrRd = read(fdPort, &chrIn,1))>0)
@@ -184,16 +184,17 @@ void* ScriptHost::RunPty(void*)
 			}
 			if (iChrRd == 0 || (iChrRd<0 && errno != EAGAIN))
 			{
+				std::cout << "ScriptHost: stdin EOF\n";
 				m_bPtyQuit = true;
 				break;
 			}
 		}
-		if (FD_ISSET(fdPort, &fdsErr)) //NOLINT
+		if (FD_ISSET(fdPort, &fdsErr)) //NOLINT pragma: LCOV_EXCL_START
 		{
 			std::cerr << "Exception reading stdio. Quit.\n";
 			m_bPtyQuit = true;
 			break;
-		}
+		} //pragma: LCOV_EXCL_STOP
 
 	}
 	// cleanup.

--- a/parts/ScriptHost.cpp
+++ b/parts/ScriptHost.cpp
@@ -154,7 +154,7 @@ void* ScriptHost::RunPty(void*)
 	fd_set fdsIn {}, fdsErr {};
 	unsigned char chrIn;
 	int iReadyRead, iChrRd;
-	std::cout << "** stdin is now accepting script commands **\n";
+	std::cout << "** ScriptHost: stdin READY **\n";
 
 	while (!m_bPtyQuit)
 	{

--- a/parts/ScriptHost.cpp
+++ b/parts/ScriptHost.cpp
@@ -24,11 +24,15 @@
 #include "gsl-lite.hpp"
 #include <GL/glew.h>  //NOLINT
 #include <GL/freeglut_std.h> // glut menus
+#include <cerrno>       // for EAGAIN, errno
 #include <cstddef>
 #include <exception>    // IWYU pragma: keep // for exception
+#include <fcntl.h>       // for open, O_NONBLOCK, O_RDWR
 #include <fstream>      // IWYU pragma: keep
 #include <iostream>
 #include <sstream>		// IWYU pragma: keep
+#include <sys/select.h>  // for FD_ISSET, FD_SET, select, FD_ZERO, fd_set
+#include <unistd.h>      // for read, write, close
 // IWYU pragma: no_include <bits/exception.h>
 
 
@@ -57,9 +61,25 @@ std::string ScriptHost::m_strCmd;
 
 std::set<std::string> ScriptHost::m_strGLAutoC;
 
+bool ScriptHost::m_bPtyStarted = false;
+std::atomic_bool ScriptHost::m_bPtyQuit = {false};
+pthread_t ScriptHost::m_ptyThread = 0;
+
 // String mutex... if interactive, for terminal->host,
 // if running a script, for host->terminal.
 std::mutex ScriptHost::m_lckScript;
+
+ScriptHost::~ScriptHost()
+{
+	if (!m_bPtyStarted)
+	{
+		return;
+	}
+	m_bPtyQuit = true;
+	pthread_cancel(m_ptyThread);
+	pthread_join(m_ptyThread,nullptr);
+	std::cout << "ScriptHost PTY closed.\n";
+}
 
 void ScriptHost::PrintScriptHelp(bool bMarkdown)
 {
@@ -118,6 +138,67 @@ bool ScriptHost::Setup(const std::string &strScript,unsigned uiFreq)
 		m_bCanAcceptInput = true;
 	}
 	return ValidateScript();
+}
+
+void ScriptHost::EnableStdio()
+{
+	pthread_create(&m_ptyThread, nullptr, RunPty, nullptr);
+	m_bPtyStarted = true;
+}
+
+void* ScriptHost::RunPty(void*)
+{
+	// Not much to see here, we just open the ports and shuttle characters back and forth across them.
+	//printf("Starting serial transfer thread...\n");
+	int fdPort = 0; // stdin, woot woot
+	fd_set fdsIn {}, fdsErr {};
+	unsigned char chrIn;
+	int iReadyRead, iChrRd;
+	std::cout << "** stdin is now accepting script commands **\n";
+
+	while (!m_bPtyQuit)
+	{
+		FD_ZERO(&fdsIn); //NOLINT // complaints in system file.
+		FD_ZERO(&fdsErr); //NOLINT
+		FD_SET(fdPort, &fdsIn); //NOLINT
+		FD_SET(fdPort, &fdsErr); //NOLINT
+		if ((iReadyRead = select(fdPort+1,&fdsIn, nullptr, &fdsErr,nullptr))<0)
+		{
+			std::cout << "Select ERR.\n";
+			m_bPtyQuit = true;
+			break;
+		}
+		if (FD_ISSET(fdPort,&fdsIn)) //NOLINT
+		{
+			while ((iChrRd = read(fdPort, &chrIn,1))>0)
+			{
+				if (chrIn == '\n')
+				{
+					KeyCB('\r'); // CR to process command.
+					KeyCB(0x1b); // ESC to clear it.
+				}
+				else
+				{
+					KeyCB(chrIn);
+				}
+			}
+			if (iChrRd == 0 || (iChrRd<0 && errno != EAGAIN))
+			{
+				m_bPtyQuit = true;
+				break;
+			}
+		}
+		if (FD_ISSET(fdPort, &fdsErr)) //NOLINT
+		{
+			std::cerr << "Exception reading stdio. Quit.\n";
+			m_bPtyQuit = true;
+			break;
+		}
+
+	}
+	// cleanup.
+	close(fdPort);
+	return nullptr;
 }
 
 void ScriptHost::_Init()

--- a/parts/ScriptHost.h
+++ b/parts/ScriptHost.h
@@ -29,6 +29,7 @@
 #include <atomic>         // for atomic_uint
 #include <map>            // for map
 #include <mutex>
+#include <pthread.h>
 #include <set>
 #include <string>         // for std::string
 #include <vector>         // for vector
@@ -67,6 +68,9 @@ class ScriptHost: public IScriptable
 		static void PrintScriptHelp(bool bMarkdown);
 
 		static void OnAVRCycle();
+
+		// Enable STDIO for scripting.
+		static void EnableStdio();
 
 		// Called to draw the terminal line.
 		static void Draw();
@@ -108,6 +112,7 @@ class ScriptHost: public IScriptable
 		LineStatus ProcessAction(unsigned int ID, const std::vector<std::string> &vArgs) override;
 
 		ScriptHost():IScriptable("ScriptHost"){}
+		~ScriptHost() override;
 
 		void _Init();
 		static ScriptHost& GetHost()
@@ -176,4 +181,10 @@ class ScriptHost: public IScriptable
 
 		static int m_iTimeoutCycles, m_iTimeoutCount;
 
+		static void* RunPty(void*);
+
+		// PTY stuff. Be careful, may cross threads!
+		static bool m_bPtyStarted;
+		static std::atomic_bool m_bPtyQuit;
+		static pthread_t m_ptyThread;
 };

--- a/scripts/tests/extra_Scripting_stdio.py
+++ b/scripts/tests/extra_Scripting_stdio.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python3
+
+# A very basic example for interfacing with scripting via stdio in Python.
+import subprocess;
+import sys;
+import codecs;
+
+process=subprocess.Popen(['stdbuf','-oL','./MK404','Prusa_MK3S', '-g','none','--test'],
+                         stdin=subprocess.PIPE,
+                         stdout=subprocess.PIPE,
+						 universal_newlines=True)
+print("Started")
+enabled = False;
+logged = False;
+for line in iter(process.stdout.readline, b''):
+	if line.rstrip():
+		print('>>> -{}-'.format(line.rstrip()))
+	if '** ScriptHost: stdin READY **' in line:
+		enabled = True;
+	if 'Starting atmega2560 execution...' in line:
+		if (not enabled):
+			sys.exit(1); # failed, scripthost wasn't ready.
+		print('Sending command\n');
+		process.stdin.write('ScriptHost::Log(test message)\n');
+		process.stdin.flush();
+	if 'ScriptLog: test message' in line:
+		logged = True;
+	if 'Script FINISHED' in line:
+		process.stdin.write('Board::Quit()\n');
+		process.stdin.flush();
+	if 'ScriptHost PTY closed.' in line:
+		break;
+print("Ended");
+exit(0);

--- a/scripts/tests/extra_Scripting_stdio.py
+++ b/scripts/tests/extra_Scripting_stdio.py
@@ -19,8 +19,6 @@ for line in iter(process.stdout.readline, b''):
 	if '** ScriptHost: stdin READY **' in line:
 		enabled = True;
 	if 'Starting atmega2560 execution...' in line:
-		if (not enabled):
-			sys.exit(1); # failed, scripthost wasn't ready.
 		print('Sending command\n');
 		process.stdin.write('ScriptHost::Log(test message)\n');
 		process.stdin.flush();
@@ -36,6 +34,7 @@ for line in iter(process.stdout.readline, b''):
 	if 'ScriptHost PTY closed.' in line:
 		break;
 print("Ended");
-if (not closed or not done):
+if (not closed or not done or not enabled or not logged):
+	print("Test failed - not all conditions met\n");
 	exit(1);
 exit(0);

--- a/scripts/tests/extra_Scripting_stdio.py
+++ b/scripts/tests/extra_Scripting_stdio.py
@@ -3,7 +3,6 @@
 # A very basic example for interfacing with scripting via stdio in Python.
 import subprocess;
 import sys;
-import codecs;
 
 process=subprocess.Popen(['stdbuf','-oL','./MK404','Prusa_MK3S', '-g','none','--test'],
                          stdin=subprocess.PIPE,
@@ -12,6 +11,8 @@ process=subprocess.Popen(['stdbuf','-oL','./MK404','Prusa_MK3S', '-g','none','--
 print("Started")
 enabled = False;
 logged = False;
+closed = False;
+done = False;
 for line in iter(process.stdout.readline, b''):
 	if line.rstrip():
 		print('>>> -{}-'.format(line.rstrip()))
@@ -25,10 +26,16 @@ for line in iter(process.stdout.readline, b''):
 		process.stdin.flush();
 	if 'ScriptLog: test message' in line:
 		logged = True;
-	if 'Script FINISHED' in line:
+	if 'ScriptHost: stdin EOF' in line:
+		closed = True;
+	if 'Script FINISHED' in line and not done:
+		done = True;
 		process.stdin.write('Board::Quit()\n');
 		process.stdin.flush();
+		process.stdin.close();
 	if 'ScriptHost PTY closed.' in line:
 		break;
 print("Ended");
+if (not closed or not done):
+	exit(1);
 exit(0);


### PR DESCRIPTION
### Description

Extend scripting to stdio so other programs can interface "live" with MK404. 

### Behaviour/ Breaking changes

None, only adds functionality. 

### Have you tested the changes?

Works locally. 

### Other

Scripting via stdio is only supported if no script file is loaded and --terminal is not enabled.

### Linked issues:

 - Closes #350 
