### PR TITLE
Always disable UART poll sleep

### DIFF
--- a/parts/Board.cpp
+++ b/parts/Board.cpp
@@ -73,7 +73,7 @@ namespace Boards {
 
 	void Board::AddSerialPty(uart_pty *UART, const char chrNum)
 	{
-		UART->Init(m_pAVR);
+		UART->Init(m_pAVR, chrNum);
 		UART->Connect(chrNum);
 	}
 

--- a/parts/boards/EinsyRambo.cpp
+++ b/parts/boards/EinsyRambo.cpp
@@ -51,8 +51,8 @@ namespace Boards
 		DisableInterruptLevelPoll(8);
 
 		AddSerialPty(&UART2,'2');
-		AddHardware(UART0);
-		AddHardware(UART1);
+		AddHardware(UART0, '0');
+		AddHardware(UART1, '1');
 
 		AddHardware(m_Mon0,'0');
 		AddHardware(m_Mon1,'1');

--- a/parts/boards/MiniRambo.cpp
+++ b/parts/boards/MiniRambo.cpp
@@ -57,7 +57,7 @@ namespace Boards
 	{
 		DisableInterruptLevelPoll(8);
 
-		AddHardware(UART0);
+		AddHardware(UART0,'0');
 
 		AddHardware(m_Mon0,'0');
 

--- a/parts/components/uart_pty.cpp
+++ b/parts/components/uart_pty.cpp
@@ -278,9 +278,13 @@ void* uart_pty::Run()
 	return nullptr;
 }
 
-void uart_pty::Init(struct avr_t * avr)
+void uart_pty::Init(struct avr_t * avr, char uart)
 {
 	_Init(avr,this);
+	uint32_t f = 0;
+	avr_ioctl(m_pAVR, AVR_IOCTL_UART_GET_FLAGS(uart), &f); //NOLINT - complaint in external macro
+	f &= ~AVR_UART_FLAG_POLL_SLEEP; // Issue #356
+	avr_ioctl(m_pAVR, AVR_IOCTL_UART_SET_FLAGS(uart), &f); //NOLINT - complaint in external macro
 
 	RegisterNotify(BYTE_IN, MAKE_C_CALLBACK(uart_pty,OnByteIn), this);
 
@@ -334,10 +338,6 @@ void uart_pty::Connect(char uart)
 	uint32_t f = 0;
 	avr_ioctl(m_pAVR, AVR_IOCTL_UART_GET_FLAGS(uart), &f); //NOLINT - complaint in external macro
 	f &= ~AVR_UART_FLAG_STDIO;
-	if (Config::Get().GetSkewCorrect())
-	{
-		f&= ~(AVR_UART_FLAG_POLL_SLEEP);
-	}
 	avr_ioctl(m_pAVR, AVR_IOCTL_UART_SET_FLAGS(uart), &f); //NOLINT - complaint in external macro
 
 	avr_irq_t * src = avr_io_getirq(m_pAVR, AVR_IOCTL_UART_GETIRQ(uart), UART_IRQ_OUTPUT); //NOLINT - complaint in external macro

--- a/parts/components/uart_pty.h
+++ b/parts/components/uart_pty.h
@@ -57,7 +57,7 @@ class uart_pty: public BasePeripheral
 		~uart_pty();
 
 		// Registers with SimAVR
-		void Init(avr_t *avr);
+		void Init(avr_t *avr, char uart);
 
 		// Actually connects to the UART.
 		void Connect(char chrUART);


### PR DESCRIPTION
### Description

Disables UART poll sleeping 

### Behaviour/ Breaking changes

Speeds up the bootloader and other poll loops, at the expense of CPU usage and a tighter spinloop

### Linked issues:

 - Closes #356 
